### PR TITLE
Item pages use recipes with src

### DIFF
--- a/Dev/ItemWikiProvider.cs
+++ b/Dev/ItemWikiProvider.cs
@@ -228,7 +228,7 @@ namespace Origins.Dev {
 						JArray stationsJson = [];
 						foreach (RecipeRequirement requirement in group.Key.requirements) {
 							if (string.IsNullOrEmpty(requirement.ToString())) continue;
-							stationsJson.Add($"`{requirement}`");
+							stationsJson.Add($"{requirement}");
 						}
 						recipeJson.Add("stations", stationsJson);
 					}
@@ -236,11 +236,11 @@ namespace Origins.Dev {
 					JArray itemsJson = [];
 					foreach (Recipe recipe in group) {
 						JObject resultsObject = [];
-						resultsObject.Add("result", $"`{WikiExtensions.GetItemText(recipe.createItem)}`");
+						resultsObject.Add("result", $"{WikiExtensions.GetItemText(recipe.createItem)}");
 
 						JArray ingredientsJson = [];
 						foreach (Item requiredItem in recipe.requiredItem) {
-							ingredientsJson.Add($"`{WikiExtensions.GetItemText(requiredItem)}`");
+							ingredientsJson.Add($"{WikiExtensions.GetItemText(requiredItem)}");
 						}
 						resultsObject.Add("ingredients", ingredientsJson);
 

--- a/Dev/WikiPageExporter.cs
+++ b/Dev/WikiPageExporter.cs
@@ -383,6 +383,11 @@ namespace Origins.Dev {
 				object value = context[name];
 				if (value is List<Recipe> recipes) {
 					StringBuilder builder = new();
+					if (context.TryGetValue("Name", out object wikiName)) {
+						string usedIn = name == "UsedIn" ? " usedIn" : "";
+						builder.Append($"<a-recipes src=\"{wikiName}\"{usedIn}></a-recipes>");
+						return builder.ToString();
+					}				
 					builder.AppendLine("<a-recipes>");
 					bool firstStation = true;
 					foreach (var group in recipes.GroupBy((r) => new RecipeRequirements(r))) {


### PR DESCRIPTION
Follow up to #7. 
Updated page exporting to use `src` when available. Additionally removed the unnecessary backticks when exporting json files.