### PR TITLE
Clean up source formatting

### DIFF
--- a/Dev/ItemWikiProvider.cs
+++ b/Dev/ItemWikiProvider.cs
@@ -76,9 +76,9 @@ namespace Origins.Dev {
 				if (Main.recipe[i].createItem.ModItem?.Mod is Origins) {
 					StringBuilder sources = GetBuilder(Main.recipe[i].createItem.type);
 					RecipeRequirements reqs = new(Main.recipe[i]);
-					string reqsText = reqs.requirements.Length > 0 ? $"(@{string.Join(", ", reqs.requirements.Select(r => r.ToString()))})" : "";
+					string reqsText = reqs.requirements.Length > 0 ? $" (@ {string.Join(", ", reqs.requirements.Select(r => r.ToString()))})" : "";
 					if (sources.Length > 0) sources.Append("<div class=divider></div>");
-					sources.Append($"{string.Join("+", Main.recipe[i].requiredItem.Select(i => (i.stack > 1 ? i.stack.ToString() : "") + WikiExtensions.GetItemText(ContentSamples.ItemsByType[i.type], imageOnly: true)))}{reqsText}");
+					sources.Append($"{string.Join(" + ", Main.recipe[i].requiredItem.Select(i => (i.stack > 1 ? $"({i.stack})" : "") + " " + WikiExtensions.GetItemText(ContentSamples.ItemsByType[i.type], imageOnly: true)))}{reqsText}");
 				}
 			}
 			foreach (AbstractNPCShop shop in NPCShopDatabase.AllShops) {

--- a/Dev/ItemWikiProvider.cs
+++ b/Dev/ItemWikiProvider.cs
@@ -76,7 +76,7 @@ namespace Origins.Dev {
 				if (Main.recipe[i].createItem.ModItem?.Mod is Origins) {
 					StringBuilder sources = GetBuilder(Main.recipe[i].createItem.type);
 					RecipeRequirements reqs = new(Main.recipe[i]);
-					string reqsText = reqs.requirements.Length > 0 ? $" (@ {string.Join(", ", reqs.requirements.Select(r => r.ToString()))})" : "";
+					string reqsText = reqs.requirements.Length > 0 ? $" (@ {string.Join(", ", reqs.requirements.Select(r => r.ToStringCompact()))})" : "";
 					if (sources.Length > 0) sources.Append("<div class=divider></div>");
 					sources.Append($"{string.Join(" + ", Main.recipe[i].requiredItem.Select(i => (i.stack > 1 ? $"({i.stack})" : "") + " " + WikiExtensions.GetItemText(ContentSamples.ItemsByType[i.type], imageOnly: true)))}{reqsText}");
 				}

--- a/Dev/WikiPageExporter.cs
+++ b/Dev/WikiPageExporter.cs
@@ -454,6 +454,7 @@ namespace Origins.Dev {
 	}
 	public abstract record class RecipeRequirement {
 		public abstract override string ToString();
+		public virtual string ToStringCompact() => ToString();
 	}
 	public record TileRecipeRequirement(int Tile) : RecipeRequirement {
 		public override string ToString() {
@@ -467,9 +468,23 @@ namespace Origins.Dev {
 			}
 			return string.Empty;
 		}
+		public override string ToStringCompact() {
+			if (requiredTileWikiTextOverride.TryGetValue(Tile, out LocalizedText text)) {
+				string key = text.Key + ".Compact";
+				return Language.Exists(key) ? Language.GetTextValue(key) : ToString();
+			}
+			return ToString();
+		}
 	}
 	public record ConditionRecipeRequirement(Condition Condition) : RecipeRequirement {
 		public override string ToString() => recipeConditionWikiTextOverride.TryGetValue(Condition, out LocalizedText text) ? text.Value : Condition.Description.Value;
+		public override string ToStringCompact() {
+			if (recipeConditionWikiTextOverride.TryGetValue(Condition, out LocalizedText text)) {
+				string key = text.Key + ".Compact";
+				return Language.Exists(key) ? Language.GetTextValue(key) : ToString();
+			}
+			return ToString();
+		}
 	}
 	public class DictionaryWithNull<TKey, TValue> : Dictionary<TKey, TValue> {
 		bool hasNullValue;

--- a/Dev/WikiPageExporter.cs
+++ b/Dev/WikiPageExporter.cs
@@ -427,7 +427,7 @@ namespace Origins.Dev {
 	}
 	public class RecipeRequirements(Recipe recipe) {
 		public readonly RecipeRequirement[] requirements =
-				recipe.requiredTile.Select(t => new TileRecipeRequirement(t))
+				recipe.requiredTile.DefaultIfEmpty(-1).Select(t => new TileRecipeRequirement(t))
 				.Concat(recipe.Conditions.Select(c => (RecipeRequirement)new ConditionRecipeRequirement(c))
 				).ToArray();
 
@@ -459,7 +459,7 @@ namespace Origins.Dev {
 		public override string ToString() {
 			if (requiredTileWikiTextOverride.TryGetValue(Tile, out LocalizedText text)) return text.Value;
 			Mod reqMod = TileLoader.GetTile(Tile)?.Mod;
-			string reqName = Lang.GetMapObjectName(MapHelper.TileToLookup(Tile, 0));
+			string reqName = Tile == -1 ? "By Hand" : Lang.GetMapObjectName(MapHelper.TileToLookup(Tile, 0));
 			if (LinkFormatters.TryGetValue(reqMod, out WikiLinkFormatter formatter)) {
 				return formatter(reqName, null, false);
 			} else {

--- a/Localization/de-DE_WikiGenerator.Generic.hjson
+++ b/Localization/de-DE_WikiGenerator.Generic.hjson
@@ -3,7 +3,11 @@
 // ImmuneToAllBuffs: All <a is=a-link>debuffs</a>
 
 RecipeConditions: {
-	// Bottle: <span style="text-align: center;"><a href=https://terraria.wiki.gg/wiki/Placed_Bottle>Placed Bottle</a><div class=or>or</div><a href=https://terraria.wiki.gg/wiki/Alchemy_Table>Alchemy Table</a></span>
+	Bottle: {
+		// Compact: <span style="text-align: center;"><a href=https://terraria.wiki.gg/wiki/Placed_Bottle>Placed Bottle</a> / <a href=https://terraria.wiki.gg/wiki/Alchemy_Table>Alchemy Table</a></span>
+		// $parentVal: <span style="text-align: center;"><a href=https://terraria.wiki.gg/wiki/Placed_Bottle>Placed Bottle</a><div class=or>or</div><a href=https://terraria.wiki.gg/wiki/Alchemy_Table>Alchemy Table</a></span>
+	}
+
 	// EctoMist: <a href=https://terraria.wiki.gg/wiki/Ecto_Mist>Ecto Mist</a>
 	// ShimmerTransmutation: <a is=a-link href=Shimmer>Shimmer Transmutation</a>
 }

--- a/Localization/en-US_WikiGenerator.Generic.hjson
+++ b/Localization/en-US_WikiGenerator.Generic.hjson
@@ -3,7 +3,11 @@ ImmuneToNormalBuffs: All <a is=a-link>debuffs</a> except Whip debuffs
 ImmuneToAllBuffs: All <a is=a-link>debuffs</a>
 
 RecipeConditions: {
-	Bottle: <span style="text-align: center;"><a href=https://terraria.wiki.gg/wiki/Placed_Bottle>Placed Bottle</a><div class=or>or</div><a href=https://terraria.wiki.gg/wiki/Alchemy_Table>Alchemy Table</a></span>
+	Bottle: {
+		Compact: <span style="text-align: center;"><a href=https://terraria.wiki.gg/wiki/Placed_Bottle>Placed Bottle</a> / <a href=https://terraria.wiki.gg/wiki/Alchemy_Table>Alchemy Table</a></span>
+		$parentVal: <span style="text-align: center;"><a href=https://terraria.wiki.gg/wiki/Placed_Bottle>Placed Bottle</a><div class=or>or</div><a href=https://terraria.wiki.gg/wiki/Alchemy_Table>Alchemy Table</a></span>
+	}
+
 	EctoMist: <a href=https://terraria.wiki.gg/wiki/Ecto_Mist>Ecto Mist</a>
 	ShimmerTransmutation: <a is=a-link href=Shimmer>Shimmer Transmutation</a>
 }


### PR DESCRIPTION
- Added spaces between ingredients and parenthesis around item counts
- Added missing "By Hand" tile requirement
- Add a compact view for requirements. This fixes a formatting issue with the `Alchemy or Bottles` station