### PR TITLE
IWikiNPC implementations

### DIFF
--- a/Dev/NPCWikiProvider.cs
+++ b/Dev/NPCWikiProvider.cs
@@ -4,6 +4,7 @@ using Origins.Buffs;
 using Origins.NPCs;
 using System.Collections.Generic;
 using Terraria;
+using Terraria.GameContent;
 using Terraria.ID;
 using Terraria.Localization;
 using Terraria.ModLoader;
@@ -130,9 +131,10 @@ namespace Origins.Dev {
 		}
 		public override IEnumerable<(string, JObject)> GetStats(ModNPC modNPC) {
 			NPC npc = modNPC.NPC;
-			if (npc.catchItem > 0) yield break;
 			string segmentText = "";
-			if (modNPC is WormBody) {
+			if (npc.catchItem > 0) {
+				segmentText = "_NPC";
+			} else if (modNPC is WormBody) {
 				segmentText = "_Body";
 			} else if (modNPC is WormTail) {
 				segmentText = "_Tail";
@@ -141,7 +143,13 @@ namespace Origins.Dev {
 		}
 		public override IEnumerable<(string, (Texture2D, int)[])> GetAnimatedSprites(ModNPC modNPC) {
 			if (modNPC is not IWikiNPC wikiNPC) yield break;
-			yield return (WikiPageExporter.GetWikiName(modNPC), SpriteGenerator.GenerateAnimationSprite(modNPC.NPC, wikiNPC.DrawRect, wikiNPC.AnimationFrames));
+			if (wikiNPC.ImageExportType == NPCExportType.Bestiary) {
+				yield return (WikiPageExporter.GetWikiName(modNPC), SpriteGenerator.GenerateAnimationSprite(modNPC.NPC, wikiNPC.DrawRect, wikiNPC.AnimationFrames, wikiNPC.FrameDuration));
+			} else if (wikiNPC.ImageExportType == NPCExportType.SpriteSheet) {
+				Main.instance.LoadNPC(modNPC.Type);
+				var texture = TextureAssets.Npc[modNPC.Type];
+				yield return (WikiPageExporter.GetWikiName(modNPC), SpriteGenerator.GenerateAnimationSprite(texture.Value, wikiNPC.AnimationFrames, wikiNPC.FrameDuration));
+			}
 		}
 	}
 }

--- a/Dev/NPCWikiProvider.cs
+++ b/Dev/NPCWikiProvider.cs
@@ -107,7 +107,7 @@ namespace Origins.Dev {
 			}
 			foreach (KeyValuePair<int, AssimilationAmount> item in assimilations) {
 				if (item.Value != default) {
-					string assName = AssimilationLoader.Debuffs[item.Key].DisplayName.Value;
+					string assName = AssimilationLoader.Debuffs[item.Key].DisplayName.Value.Replace(" ", "");
 					if (item.Value.Function is not null) {
 						data.Add(assName, "variable");
 						continue;

--- a/Dev/NPCWikiProvider.cs
+++ b/Dev/NPCWikiProvider.cs
@@ -120,6 +120,9 @@ namespace Origins.Dev {
 			data.AppendJStat("Expert", expertData, []);
 			data.AppendJStat("Master", masterData, []);
 
+			JArray environments = WikiExtensions.GetEnvironment(ContentSamples.NpcsByNetId[modNPC.Type]);
+			data.AppendJStat("Environment", environments, []);
+
 			customStat?.ModifyWikiStats(data);
 			if (!data.ContainsKey("SpriteWidth")) data.AppendStat("SpriteWidth", modNPC is null ? npc.width : ModContent.Request<Texture2D>(modNPC.Texture).Width(), 0);
 			if (!data.ContainsKey("InternalName")) data.AppendStat("InternalName", modNPC?.Name, null);

--- a/Dev/NPCWikiProvider.cs
+++ b/Dev/NPCWikiProvider.cs
@@ -143,12 +143,18 @@ namespace Origins.Dev {
 		}
 		public override IEnumerable<(string, (Texture2D, int)[])> GetAnimatedSprites(ModNPC modNPC) {
 			if (modNPC is not IWikiNPC wikiNPC) yield break;
+			string savePath = (modNPC as ICustomWikiStat)?.CustomSpritePath ?? WikiPageExporter.GetWikiName(modNPC);
 			if (wikiNPC.ImageExportType == NPCExportType.Bestiary) {
-				yield return (WikiPageExporter.GetWikiName(modNPC), SpriteGenerator.GenerateAnimationSprite(modNPC.NPC, wikiNPC.DrawRect, wikiNPC.AnimationFrames, wikiNPC.FrameDuration));
+				yield return (savePath, SpriteGenerator.GenerateAnimationSprite(modNPC.NPC, wikiNPC.DrawRect, wikiNPC.AnimationFrames, wikiNPC.FrameDuration));
 			} else if (wikiNPC.ImageExportType == NPCExportType.SpriteSheet) {
 				Main.instance.LoadNPC(modNPC.Type);
 				var texture = TextureAssets.Npc[modNPC.Type];
-				yield return (WikiPageExporter.GetWikiName(modNPC), SpriteGenerator.GenerateAnimationSprite(texture.Value, wikiNPC.AnimationFrames, wikiNPC.FrameDuration));
+				(Rectangle frame, int frames)[] frames = new (Rectangle frame, int frames)[wikiNPC.AnimationFrames];
+				for (int i = 0; i < frames.Length; i++) {
+					Rectangle newFrame = wikiNPC.DrawRect with { Y = wikiNPC.DrawRect.Y + wikiNPC.DrawRect.Height * i };
+					frames[i] = (newFrame, wikiNPC.FrameDuration);
+				}
+				yield return (savePath, SpriteGenerator.GenerateAnimationSprite(texture.Value, frames));
 			}
 		}
 	}

--- a/Dev/NPCWikiProvider.cs
+++ b/Dev/NPCWikiProvider.cs
@@ -145,7 +145,7 @@ namespace Origins.Dev {
 			if (modNPC is not IWikiNPC wikiNPC) yield break;
 			string savePath = (modNPC as ICustomWikiStat)?.CustomSpritePath ?? WikiPageExporter.GetWikiName(modNPC);
 			if (wikiNPC.ImageExportType == NPCExportType.Bestiary) {
-				yield return (savePath, SpriteGenerator.GenerateAnimationSprite(modNPC.NPC, wikiNPC.DrawRect, wikiNPC.AnimationFrames, wikiNPC.FrameDuration));
+				yield return (savePath, SpriteGenerator.GenerateAnimationSprite(modNPC.NPC, wikiNPC.DrawRect, wikiNPC.AnimationFrames, wikiNPC.FrameDuration)[wikiNPC.FrameRange]);
 			} else if (wikiNPC.ImageExportType == NPCExportType.SpriteSheet) {
 				Main.instance.LoadNPC(modNPC.Type);
 				var texture = TextureAssets.Npc[modNPC.Type];

--- a/Dev/SpriteGenerator.cs
+++ b/Dev/SpriteGenerator.cs
@@ -182,7 +182,7 @@ namespace Origins.Dev {
 			animation.Frame = frameNum;
 			return frames;
 		}
-		public static (Texture2D texture, int frames)[] GenerateAnimationSprite(NPC npc, Rectangle area, int ticks) {
+		public static (Texture2D texture, int frames)[] GenerateAnimationSprite(NPC npc, Rectangle area, int ticks, int framesPerFrame = 1) {
 			(Texture2D texture, int frames)[] frames = new (Texture2D texture, int frames)[ticks];
 			UnlockableNPCEntryIcon icon = new(npc.netID);
 			EntryIconDrawSettings iconDrawSettings = new() {
@@ -196,7 +196,7 @@ namespace Origins.Dev {
 						icon.Draw(default, spriteBatch, iconDrawSettings);
 					},
 					(area.Width, area.Height)
-				), 1);
+				), framesPerFrame);
 			}
 			return frames;
 		}

--- a/Dev/WikiImageExporter.cs
+++ b/Dev/WikiImageExporter.cs
@@ -155,11 +155,10 @@ namespace Origins.Dev {
 				if (i == 0) {
 					fileBufferStream.Write(buffer, 0, IDAT_pos);
 					fileBufferStream.Write([0x00, 0x00, 0x00, 0x08], 0, 4);
-					WriteAndAdvanceCRC(fileBufferStream, ref crc32, [
-						/*acTL      */0x61, 0x63, 0x54, 0x4C,
-								/*num_frames*/0x00, 0x00, 0x00, (byte)textures.Length,
-								/*num_plays */0x00, 0x00, 0x00, 0xFF
-					]);
+					WriteAndAdvanceCRC(fileBufferStream, ref crc32, "acTL"u8.ToArray());
+					WriteAndAdvanceCRC(fileBufferStream, ref crc32, ToBytes((uint)textures.Length), name: "num_frames");
+					WriteAndAdvanceCRC(fileBufferStream, ref crc32, BitConverter.GetBytes((uint)0), name: "num_plays");
+
 					FinalizeCRC((uint)crc32, fileBufferStream);
 				}
 

--- a/Dev/WikiPageExporter.cs
+++ b/Dev/WikiPageExporter.cs
@@ -3,6 +3,7 @@ using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using Origins.Reflection;
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -13,6 +14,7 @@ using System.Net;
 using System.Reflection;
 using System.Text;
 using Terraria;
+using Terraria.GameContent.Bestiary;
 using Terraria.GameContent.ItemDropRules;
 using Terraria.ID;
 using Terraria.Localization;
@@ -752,6 +754,25 @@ namespace Origins.Dev {
 				if (npc.buffImmune[i] && (i < BuffID.Count || ModContent.GetModBuff(i).Mod is Origins)) immunities.Add(GetBuffText(i));
 			}
 			return immunities;
+		}
+		public static JArray GetEnvironment(this NPC npc) {
+			BestiaryEntry entry = Main.BestiaryDB.FindEntryByNPCID(npc.type);
+			JArray environments = [];
+			foreach (var info in entry.Info) {
+				if (info is ModBiomeBestiaryInfoElement biomeInfo) {
+					Mod mod = ModBestiaryInfoElementMethods._mod.GetValue(biomeInfo);
+					AddEnvironment(mod, biomeInfo);
+				} else if (info is FilterProviderInfoElement filter) {
+					AddEnvironment(null, filter);
+				}
+			}
+			void AddEnvironment(Mod mod, IFilterInfoProvider info) {
+				string name = Language.GetTextValue(info.GetDisplayNameKey());
+				if (LinkFormatters.TryGetValue(mod, out WikiLinkFormatter formatter)) {
+					environments.Add(formatter(name, null, false));
+				}
+			}
+			return environments;
 		}
 		public static (List<Recipe> recipes, List<Recipe> usedIn) GetRecipes(Item item) {
 			List<Recipe> recipes = [];

--- a/Dev/WikiPageExporter.cs
+++ b/Dev/WikiPageExporter.cs
@@ -581,6 +581,7 @@ namespace Origins.Dev {
 		int AnimationFrames { get; }
 		int FrameDuration => 1;
 		NPCExportType ImageExportType => NPCExportType.Bestiary;
+		Range FrameRange => new Range(0, AnimationFrames);
 	}
 	public enum NPCExportType {
 		Bestiary,

--- a/Dev/WikiPageExporter.cs
+++ b/Dev/WikiPageExporter.cs
@@ -578,6 +578,12 @@ namespace Origins.Dev {
 	public interface IWikiNPC {
 		Rectangle DrawRect { get; }
 		int AnimationFrames { get; }
+		int FrameDuration => 1;
+		NPCExportType ImageExportType => NPCExportType.Bestiary;
+	}
+	public enum NPCExportType {
+		Bestiary,
+		SpriteSheet,
 	}
 	public interface INoSeperateWikiPage { }
 	public class StatOnlyItemWikiProvider : ItemWikiProvider {

--- a/Dev/WikiPageExporter.cs
+++ b/Dev/WikiPageExporter.cs
@@ -169,6 +169,7 @@ namespace Origins.Dev {
 		public static string GetWikiPagePath(string name) => Path.Combine(DebugConfig.Instance.WikiPagePath, name + ".html");
 		public static string GetWikiStatPath(string name) => Path.Combine(DebugConfig.Instance.StatJSONPath, name + ".json");
 		public static string GetWikiItemImagePath(ModItem modItem) => Main.itemAnimations[modItem.Type] is not null ? modItem.Name.Replace(' ', '_') : modItem.Texture.Replace(modItem.Mod.Name, "§ModImage§");
+		public static string GetWikiImagePath(string path) => string.Join('/', "§ModImage§", path);
 		public static string GetWikiItemRarity(Item item) => (RarityLoader.GetRarity(item.rare)?.Name ?? ItemRarityID.Search.GetName(item.rare)).Replace("Rarity", "");
 		public void Unload() {
 			wikiTemplate = null;

--- a/Localization/de-DE_WikiGenerator.Generic.hjson
+++ b/Localization/de-DE_WikiGenerator.Generic.hjson
@@ -18,7 +18,7 @@ RecipeConditions: {
 	// Anvils: <a is=a-link href=https://terraria.wiki.gg/wiki/Anvils>Any Anvil</a>
 	// MythrilAnvil: <a is=a-link href=https://terraria.wiki.gg/wiki/Hardmode_Anvil>Any Hardmode Anvil</a>
 	// WorkBenches: <a is=a-link href=Work_Benches>Work Bench</a>
-	// RivenWater: <a is="a-link" image="Tiles/Riven_Water">Riven Water</a>
+	// RivenWater: <a is="a-link" image="Tiles/Riven_Water" href="Riven_Hive.html">Riven Water</a>
 }
 
 DropConditions: {

--- a/Localization/en-US_WikiGenerator.Generic.hjson
+++ b/Localization/en-US_WikiGenerator.Generic.hjson
@@ -18,7 +18,7 @@ RecipeConditions: {
 	Anvils: <a is=a-link href=https://terraria.wiki.gg/wiki/Anvils>Any Anvil</a>
 	MythrilAnvil: <a is=a-link href=https://terraria.wiki.gg/wiki/Hardmode_Anvil>Any Hardmode Anvil</a>
 	WorkBenches: <a is=a-link href=Work_Benches>Work Bench</a>
-	RivenWater: <a is="a-link" image="Tiles/Riven_Water">Riven Water</a>
+	RivenWater: <a is="a-link" image="Tiles/Riven_Water" href="Riven_Hive.html">Riven Water</a>
 }
 
 DropConditions: {

--- a/NPCs/Brine/Carpalfish.cs
+++ b/NPCs/Brine/Carpalfish.cs
@@ -2,6 +2,7 @@
 using CalamityMod.NPCs.ExoMechs;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
+using Origins.Dev;
 using Origins.Items.Accessories;
 using Origins.Items.Armor.Defiled;
 using Origins.Items.Materials;
@@ -25,7 +26,11 @@ using Terraria.ModLoader;
 using static Origins.Misc.Physics;
 
 namespace Origins.NPCs.Brine {
-	public class Carpalfish : Brine_Pool_NPC, IItemObtainabilityProvider {
+	public class Carpalfish : Brine_Pool_NPC, IItemObtainabilityProvider, IWikiNPC {
+		public Rectangle DrawRect => new(0, 0, 80, 30);
+		public int AnimationFrames => 16;
+		public int FrameDuration => 4;
+
 		public IEnumerable<int> ProvideItemObtainability() => [ModContent.ItemType<Venom_Fang>()];
 		public override void SetStaticDefaults() {
 			base.SetStaticDefaults();

--- a/NPCs/Brine/King_Crab.cs
+++ b/NPCs/Brine/King_Crab.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Xna.Framework.Graphics;
+using Origins.Dev;
 using Origins.Items.Materials;
 using Origins.World.BiomeData;
 using System;
@@ -9,7 +10,11 @@ using Terraria.ID;
 using Terraria.ModLoader;
 
 namespace Origins.NPCs.Brine {
-	public class King_Crab : Brine_Pool_NPC, IMeleeCollisionDataNPC {
+	public class King_Crab : Brine_Pool_NPC, IMeleeCollisionDataNPC, IWikiNPC {
+		public Rectangle DrawRect => new(0, 0, 62, 60);
+		public int AnimationFrames => 1;
+		public int FrameDuration => 1;
+		public NPCExportType ImageExportType => NPCExportType.Bestiary;
 		public override void SetStaticDefaults() {
 			base.SetStaticDefaults();
 			Main.npcFrameCount[NPC.type] = 5;

--- a/NPCs/Brine/Mildew_Creeper.cs
+++ b/NPCs/Brine/Mildew_Creeper.cs
@@ -3,6 +3,7 @@ using CalamityMod.NPCs.ExoMechs;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Origins.Buffs;
+using Origins.Dev;
 using Origins.Items.Accessories;
 using Origins.Items.Armor.Defiled;
 using Origins.Items.Materials;
@@ -26,7 +27,11 @@ using Terraria.ModLoader;
 using static Origins.Misc.Physics;
 
 namespace Origins.NPCs.Brine {
-	public class Mildew_Creeper : Brine_Pool_NPC, IMeleeCollisionDataNPC {
+	public class Mildew_Creeper : Brine_Pool_NPC, IMeleeCollisionDataNPC, IWikiNPC {
+		public Rectangle DrawRect => new(0, -8, 50, 112);
+		public int AnimationFrames => 1;
+		public int FrameDuration => 1;
+		public NPCExportType ImageExportType => NPCExportType.Bestiary;
 		public override void SetStaticDefaults() {
 			base.SetStaticDefaults();
 			NPCID.Sets.NPCBestiaryDrawOffset[Type] = new NPCID.Sets.NPCBestiaryDrawModifiers() {

--- a/NPCs/Brine/Sea_Dragon.cs
+++ b/NPCs/Brine/Sea_Dragon.cs
@@ -3,6 +3,7 @@ using CalamityMod.NPCs.ExoMechs;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Origins.Buffs;
+using Origins.Dev;
 using Origins.Items.Armor.Defiled;
 using Origins.Items.Materials;
 using Origins.Items.Other.Consumables.Food;
@@ -24,7 +25,12 @@ using Terraria.ModLoader;
 using static Origins.Misc.Physics;
 
 namespace Origins.NPCs.Brine {
-	public class Sea_Dragon : Brine_Pool_NPC {
+	public class Sea_Dragon : Brine_Pool_NPC, IWikiNPC {
+		public Rectangle DrawRect => new(-28, 0, 94, 26);
+		public int AnimationFrames => 64;
+		public int FrameDuration => 1;
+		public NPCExportType ImageExportType => NPCExportType.Bestiary;
+		public Range FrameRange => new Range(28, 64);
 		AutoLoadingAsset<Texture2D> strandTexture = typeof(Sea_Dragon).GetDefaultTMLName() + "_Strand";
 		public override void SetStaticDefaults() {
 			base.SetStaticDefaults();

--- a/NPCs/Critters/Critters.cs
+++ b/NPCs/Critters/Critters.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Xna.Framework;
+using Origins.Dev;
 using Origins.Items.Other.Fish;
 using Origins.World.BiomeData;
 using rail;
@@ -9,7 +10,11 @@ using Terraria.ID;
 using Terraria.ModLoader;
 
 namespace Origins.NPCs.Critters {
-	public class Amoeba_Buggy : Glowing_Mod_NPC {
+	public class Amoeba_Buggy : Glowing_Mod_NPC, IWikiNPC {
+		public Rectangle DrawRect => new(0, 0, 18, 12);
+		public int AnimationFrames => 4;
+		public int FrameDuration => 8;
+		public NPCExportType ImageExportType => NPCExportType.SpriteSheet;
 		public override void SetStaticDefaults() {
 			Main.npcCatchable[Type] = true;
 			Main.npcFrameCount[Type] = 4;
@@ -37,7 +42,11 @@ namespace Origins.NPCs.Critters {
 			}
 		}
 	}
-	public class Bug : ModNPC {
+	public class Bug : ModNPC, IWikiNPC {
+		public Rectangle DrawRect => new(0, 0, 20, 12);
+		public int AnimationFrames => 2;
+		public int FrameDuration => 8;
+		public NPCExportType ImageExportType => NPCExportType.SpriteSheet;
 		public override void SetStaticDefaults() {
 			Main.npcCatchable[Type] = true;
 			Main.npcFrameCount[Type] = 2;

--- a/NPCs/Critters/Critters.cs
+++ b/NPCs/Critters/Critters.cs
@@ -97,7 +97,11 @@ namespace Origins.NPCs.Critters {
 			}
 		}
 	}
-	public class Cicada_3301 : ModNPC {
+	public class Cicada_3301 : ModNPC, IWikiNPC {
+		public Rectangle DrawRect => new(0, 0, 20, 13);
+		public int AnimationFrames => 2;
+		public int FrameDuration => 8;
+		public NPCExportType ImageExportType => NPCExportType.SpriteSheet;
 		public override void SetStaticDefaults() {
 			Main.npcCatchable[Type] = true;
 			Main.npcFrameCount[Type] = 2;

--- a/NPCs/Defiled/Ancient_Defiled_Cyclops.cs
+++ b/NPCs/Defiled/Ancient_Defiled_Cyclops.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Xna.Framework;
+using Origins.Dev;
 using Origins.Items.Armor.Defiled;
 using Origins.Items.Materials;
 using Origins.Items.Weapons.Ranged;
@@ -11,9 +12,13 @@ using Terraria.ID;
 using Terraria.ModLoader;
 
 namespace Origins.NPCs.Defiled {
-	public class Ancient_Defiled_Cyclops : ModNPC, IMeleeCollisionDataNPC, IDefiledEnemy {
+	public class Ancient_Defiled_Cyclops : ModNPC, IMeleeCollisionDataNPC, IDefiledEnemy, IWikiNPC {
 		public const float speedMult = 1f;
 		bool attacking = false;
+		public Rectangle DrawRect => new(-3, 6, 90, 118);
+		public int AnimationFrames => 1;
+		public int FrameDuration => 1;
+		public NPCExportType ImageExportType => NPCExportType.Bestiary;
 		public override void SetStaticDefaults() {
 			Main.npcFrameCount[Type] = 7;
 			ItemID.Sets.KillsToBanner[Type] *= 3;

--- a/NPCs/Defiled/Ancient_Defiled_Flyer.cs
+++ b/NPCs/Defiled/Ancient_Defiled_Flyer.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Xna.Framework;
+using Origins.Dev;
 using Origins.Items.Armor.Defiled;
 using Origins.Items.Materials;
 using Origins.Items.Other.Consumables.Food;
@@ -11,7 +12,11 @@ using Terraria.ID;
 using Terraria.ModLoader;
 
 namespace Origins.NPCs.Defiled {
-	public class Ancient_Defiled_Flyer : ModNPC {
+	public class Ancient_Defiled_Flyer : ModNPC, IWikiNPC {
+		public Rectangle DrawRect => new(0, 34, 136, 44);
+		public int AnimationFrames => 24;
+		public int FrameDuration => 1;
+		public NPCExportType ImageExportType => NPCExportType.Bestiary;
 		public override void SetStaticDefaults() {
 			Main.npcFrameCount[NPC.type] = 4;
 			NPCID.Sets.NPCBestiaryDrawOffset[Type] = new NPCID.Sets.NPCBestiaryDrawModifiers() {

--- a/NPCs/Defiled/Bile_Thrower.cs
+++ b/NPCs/Defiled/Bile_Thrower.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Xna.Framework;
 using Origins.Buffs;
+using Origins.Dev;
 using Origins.Projectiles.Enemies;
 using PegasusLib;
 using Terraria;
@@ -10,7 +11,11 @@ using Terraria.ModLoader;
 using Tyfyter.Utils;
 
 namespace Origins.NPCs.Defiled {
-	public class Bile_Thrower : Glowing_Mod_NPC, IDefiledEnemy {
+	public class Bile_Thrower : Glowing_Mod_NPC, IDefiledEnemy, IWikiNPC {
+		public Rectangle DrawRect => new(0, 4, 28, 42);
+		public int AnimationFrames => 12;
+		public int FrameDuration => 2;
+		public NPCExportType ImageExportType => NPCExportType.Bestiary;
 		public int MaxMana => 40;
 		public int MaxManaDrain => 5;
 		public float Mana {

--- a/NPCs/Defiled/Chunky_Slime.cs
+++ b/NPCs/Defiled/Chunky_Slime.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics.PackedVector;
+using Origins.Dev;
 using Origins.World.BiomeData;
 using Terraria;
 using Terraria.GameContent.Bestiary;
@@ -8,7 +9,11 @@ using Terraria.ID;
 using Terraria.ModLoader;
 
 namespace Origins.NPCs.Defiled {
-	public class Chunky_Slime : ModNPC, IDefiledEnemy {
+	public class Chunky_Slime : ModNPC, IDefiledEnemy, IWikiNPC {
+		public Rectangle DrawRect => new(0, 0, 32, 26);
+		public int AnimationFrames => 2;
+		public int FrameDuration => 8;
+		public NPCExportType ImageExportType => NPCExportType.SpriteSheet;
 		public AssimilationAmount? Assimilation => 0.05f;
 		public override void SetStaticDefaults() {
 			Main.npcFrameCount[NPC.type] = 2;

--- a/NPCs/Defiled/Defiled_Asphyxiator.cs
+++ b/NPCs/Defiled/Defiled_Asphyxiator.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Xna.Framework;
+using Origins.Dev;
 using Origins.Items.Materials;
 using Origins.World.BiomeData;
 using System;
@@ -11,7 +12,11 @@ using Terraria.ID;
 using Terraria.ModLoader;
 
 namespace Origins.NPCs.Defiled {
-	public class Defiled_Asphyxiator : Glowing_Mod_NPC, IDefiledEnemy {
+	public class Defiled_Asphyxiator : Glowing_Mod_NPC, IDefiledEnemy, IWikiNPC {
+		public Rectangle DrawRect => new(0, 0, 92, 58);
+		public int AnimationFrames => 36;
+		public int FrameDuration => 1;
+		public NPCExportType ImageExportType => NPCExportType.Bestiary;
 		public AssimilationAmount? Assimilation => 0.11f;
 		public const float speedMult = 0.75f;
 		//public float SpeedMult => npc.frame.Y==510?1.6f:0.8f;

--- a/NPCs/Defiled/Defiled_Brute.cs
+++ b/NPCs/Defiled/Defiled_Brute.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Xna.Framework;
+using Origins.Dev;
 using Origins.Items.Armor.Defiled;
 using Origins.Items.Materials;
 using Origins.Items.Weapons.Demolitionist;
@@ -12,7 +13,11 @@ using Terraria.ID;
 using Terraria.ModLoader;
 
 namespace Origins.NPCs.Defiled {
-	public class Defiled_Brute : Glowing_Mod_NPC, IDefiledEnemy {
+	public class Defiled_Brute : Glowing_Mod_NPC, IDefiledEnemy, IWikiNPC {
+		public Rectangle DrawRect => new(0, 4, 74, 62);
+		public int AnimationFrames => 16;
+		public int FrameDuration => 1;
+		public NPCExportType ImageExportType => NPCExportType.Bestiary;
 		public AssimilationAmount? Assimilation => 0.08f;
 		public const float speedMult = 0.75f;
 		//public float SpeedMult => npc.frame.Y==510?1.6f:0.8f;

--- a/NPCs/Defiled/Defiled_Cyclops.cs
+++ b/NPCs/Defiled/Defiled_Cyclops.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Xna.Framework;
+using Origins.Dev;
 using Origins.Items.Armor.Defiled;
 using Origins.Items.Materials;
 using Origins.Items.Weapons.Melee;
@@ -13,7 +14,11 @@ using Terraria.ID;
 using Terraria.ModLoader;
 
 namespace Origins.NPCs.Defiled {
-	public class Defiled_Cyclops : Glowing_Mod_NPC, IDefiledEnemy {
+	public class Defiled_Cyclops : Glowing_Mod_NPC, IDefiledEnemy, IWikiNPC {
+		public Rectangle DrawRect => new(0, 4, 52, 66);
+		public int AnimationFrames => 32;
+		public int FrameDuration => 1;
+		public NPCExportType ImageExportType => NPCExportType.Bestiary;
 		public AssimilationAmount? Assimilation => 0.08f;
 		public const float speedMult = 1f;
 		public override void SetStaticDefaults() {

--- a/NPCs/Defiled/Defiled_Ekko.cs
+++ b/NPCs/Defiled/Defiled_Ekko.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Xna.Framework;
+using Origins.Dev;
 using Origins.Items.Materials;
 using Origins.World.BiomeData;
 using Terraria;
@@ -9,7 +10,11 @@ using Terraria.ID;
 using Terraria.ModLoader;
 
 namespace Origins.NPCs.Defiled {
-	public class Defiled_Ekko : ModNPC, IDefiledEnemy {
+	public class Defiled_Ekko : ModNPC, IDefiledEnemy, IWikiNPC {
+		public Rectangle DrawRect => new(0, 0, 28, 46);
+		public int AnimationFrames => 1;
+		public int FrameDuration => 1;
+		public NPCExportType ImageExportType => NPCExportType.SpriteSheet;
 		public AssimilationAmount? Assimilation => 0.04f;
 		public override void SetStaticDefaults() {
 			Main.npcFrameCount[NPC.type] = 14;

--- a/NPCs/Defiled/Defiled_Flyer.cs
+++ b/NPCs/Defiled/Defiled_Flyer.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
+using Origins.Dev;
 using Origins.Items.Armor.Defiled;
 using Origins.Items.Materials;
 using Origins.Items.Other.Consumables.Food;
@@ -20,8 +21,12 @@ using Terraria.ID;
 using Terraria.ModLoader;
 
 namespace Origins.NPCs.Defiled {
-	public class Defiled_Flyer : Glowing_Mod_NPC, IDefiledEnemy {
+	public class Defiled_Flyer : Glowing_Mod_NPC, IDefiledEnemy, IWikiNPC {
 		public AssimilationAmount? Assimilation => 0.05f;
+		public Rectangle DrawRect => new(-30, 28, 104, 38);
+		public int AnimationFrames => 1;
+		public int FrameDuration => 1;
+		public NPCExportType ImageExportType => NPCExportType.Bestiary;
 		public override void SetStaticDefaults() {
 			Main.npcFrameCount[NPC.type] = 4;
 			NPCID.Sets.NPCBestiaryDrawOffset[Type] = new NPCID.Sets.NPCBestiaryDrawModifiers() {

--- a/NPCs/Defiled/Defiled_Mimic.cs
+++ b/NPCs/Defiled/Defiled_Mimic.cs
@@ -1,4 +1,5 @@
-﻿using Origins.Items.Mounts;
+﻿using Origins.Dev;
+using Origins.Items.Mounts;
 using Origins.Items.Tools;
 using Origins.Items.Weapons.Magic;
 using Origins.Items.Weapons.Ranged;
@@ -10,7 +11,11 @@ using Terraria.ID;
 using Terraria.ModLoader;
 
 namespace Origins.NPCs.Defiled {
-	public class Defiled_Mimic : Glowing_Mod_NPC, IDefiledEnemy {
+	public class Defiled_Mimic : Glowing_Mod_NPC, IDefiledEnemy, IWikiNPC {
+		public Rectangle DrawRect => new(0, 0, 60, 50);
+		public int AnimationFrames => 1;
+		public int FrameDuration => 1;
+		public NPCExportType ImageExportType => NPCExportType.Bestiary;
 		public override void SetStaticDefaults() {
 			Main.npcFrameCount[NPC.type] = 14;
 			NPCID.Sets.SpecificDebuffImmunity[Type][BuffID.Confused] = true;

--- a/NPCs/Defiled/Defiled_Mite.cs
+++ b/NPCs/Defiled/Defiled_Mite.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
+using Origins.Dev;
 using Origins.Items.Armor.Defiled;
 using Origins.World.BiomeData;
 using System;
@@ -12,11 +13,15 @@ using Terraria.ID;
 using Terraria.ModLoader;
 
 namespace Origins.NPCs.Defiled {
-	public class Defiled_Mite : Glowing_Mod_NPC, IDefiledEnemy {
+	public class Defiled_Mite : Glowing_Mod_NPC, IDefiledEnemy, IWikiNPC {
 		internal const int spawnCheckDistance = 15;
 		public const int aggroRange = 128;
 		byte frame = 0;
 		byte anger = 0;
+		public Rectangle DrawRect => new(0, 6, 34, 28);
+		public int AnimationFrames => 1;
+		public int FrameDuration => 1;
+		public NPCExportType ImageExportType => NPCExportType.Bestiary;
 		public override void SetStaticDefaults() {
 			Main.npcFrameCount[NPC.type] = 5;
 			DefiledGlobalNPC.NPCTransformations.Add(NPCID.Bunny, Type);

--- a/NPCs/Defiled/Defiled_Pigron.cs
+++ b/NPCs/Defiled/Defiled_Pigron.cs
@@ -1,4 +1,6 @@
 ﻿using Microsoft.Xna.Framework;
+using Newtonsoft.Json.Linq;
+using Origins.Dev;
 using Origins.Items.Accessories;
 using Origins.Items.Weapons.Ranged;
 using Origins.World.BiomeData;
@@ -9,7 +11,11 @@ using Terraria.ID;
 using Terraria.ModLoader;
 
 namespace Origins.NPCs.Defiled {
-	public class Defiled_Pigron : ModNPC, IDefiledEnemy {
+	public class Defiled_Pigron : ModNPC, IDefiledEnemy, ICustomWikiStat {
+		void ICustomWikiStat.ModifyWikiStats(JObject data) {
+			data["Name"] = "Defiled Pigron";
+		}
+		string ICustomWikiStat.CustomStatPath => "Defiled_Pigron";
 		public int MaxMana => 20;
 		public int MaxManaDrain => 10;
 		public float Mana { get; set; }

--- a/NPCs/Defiled/Defiled_Pigron.cs
+++ b/NPCs/Defiled/Defiled_Pigron.cs
@@ -11,11 +11,16 @@ using Terraria.ID;
 using Terraria.ModLoader;
 
 namespace Origins.NPCs.Defiled {
-	public class Defiled_Pigron : ModNPC, IDefiledEnemy, ICustomWikiStat {
+	public class Defiled_Pigron : ModNPC, IDefiledEnemy, ICustomWikiStat, IWikiNPC {
+		public Rectangle DrawRect => new(-8, 16, 80, 66);
+		public int AnimationFrames => 56;
+		public int FrameDuration => 1;
+		public NPCExportType ImageExportType => NPCExportType.Bestiary;
 		void ICustomWikiStat.ModifyWikiStats(JObject data) {
 			data["Name"] = "Defiled Pigron";
 		}
 		string ICustomWikiStat.CustomStatPath => "Defiled_Pigron";
+		string ICustomWikiStat.CustomSpritePath => "Defiled_Pigron";
 		public int MaxMana => 20;
 		public int MaxManaDrain => 10;
 		public float Mana { get; set; }

--- a/NPCs/Defiled/Defiled_Squid.cs
+++ b/NPCs/Defiled/Defiled_Squid.cs
@@ -1,6 +1,7 @@
 ﻿using AltLibrary.Common.AltBiomes;
 using Microsoft.Xna.Framework;
 using Origins.Buffs;
+using Origins.Dev;
 using Origins.Dusts;
 using Origins.Items.Materials;
 using Origins.Projectiles.Enemies;
@@ -13,7 +14,11 @@ using Terraria.ModLoader;
 using Terraria.Utilities;
 
 namespace Origins.NPCs.Defiled {
-	public class Defiled_Squid : Glowing_Mod_NPC, IDefiledEnemy {
+	public class Defiled_Squid : Glowing_Mod_NPC, IDefiledEnemy, IWikiNPC {
+		public Rectangle DrawRect => new(0, -8, 30, 48);
+		public int AnimationFrames => 1;
+		public int FrameDuration => 1;
+		public NPCExportType ImageExportType => NPCExportType.Bestiary;
 		public int MaxMana => 32;
 		public int MaxManaDrain => 8;
 		public float Mana {

--- a/NPCs/Defiled/Defiled_Swarmer.cs
+++ b/NPCs/Defiled/Defiled_Swarmer.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Xna.Framework;
+using Origins.Dev;
 using Origins.Items.Materials;
 using Origins.Tiles.Defiled;
 using Origins.World.BiomeData;
@@ -12,7 +13,11 @@ using Terraria.ID;
 using Terraria.ModLoader;
 
 namespace Origins.NPCs.Defiled {
-	public class Defiled_Swarmer : Glowing_Mod_NPC, IDefiledEnemy {
+	public class Defiled_Swarmer : Glowing_Mod_NPC, IDefiledEnemy, IWikiNPC {
+		public Rectangle DrawRect => new(0, 36, 28, 28);
+		public int AnimationFrames => 18;
+		public int FrameDuration => 1;
+		public NPCExportType ImageExportType => NPCExportType.Bestiary;
 		public AssimilationAmount? Assimilation => 0.02f;
 		public override void SetStaticDefaults() {
 			Main.npcFrameCount[Type] = 3;

--- a/NPCs/Defiled/Defiled_Tripod.cs
+++ b/NPCs/Defiled/Defiled_Tripod.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Xna.Framework.Graphics;
 using Origins.Buffs;
+using Origins.Dev;
 using Origins.Items.Accessories;
 using Origins.Items.Materials;
 using Origins.Tiles;
@@ -18,7 +19,11 @@ using Terraria.ModLoader;
 using static Origins.OriginExtensions;
 
 namespace Origins.NPCs.Defiled {
-	public class Defiled_Tripod : Glowing_Mod_NPC, ICustomCollisionNPC, IDefiledEnemy {
+	public class Defiled_Tripod : Glowing_Mod_NPC, ICustomCollisionNPC, IDefiledEnemy, IWikiNPC {
+		public Rectangle DrawRect => new(0, 4, 98, 100);
+		public int AnimationFrames => 24;
+		public int FrameDuration => 1;
+		public NPCExportType ImageExportType => NPCExportType.Bestiary;
 		public AssimilationAmount? Assimilation => 0.07f;
 		public const float horizontalSpeed = 3.2f;
 		public const float horizontalAirSpeed = 2f;

--- a/NPCs/Defiled/Defiled_Watcher.cs
+++ b/NPCs/Defiled/Defiled_Watcher.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Xna.Framework;
 using Origins.Buffs;
+using Origins.Dev;
 using Origins.Items.Armor.Defiled;
 using Origins.Items.Materials;
 using Origins.Items.Weapons.Demolitionist;
@@ -20,7 +21,11 @@ using Terraria.ModLoader;
 using Tyfyter.Utils;
 
 namespace Origins.NPCs.Defiled {
-	public class Defiled_Watcher : Glowing_Mod_NPC, IDefiledEnemy {
+	public class Defiled_Watcher : Glowing_Mod_NPC, IDefiledEnemy, IWikiNPC {
+		public Rectangle DrawRect => new(0, 0, 74, 68);
+		public int AnimationFrames => 24;
+		public int FrameDuration => 1;
+		public NPCExportType ImageExportType => NPCExportType.Bestiary;
 		public AssimilationAmount? Assimilation => 0.03f;
 		public override void SetStaticDefaults() {
 			Main.npcFrameCount[NPC.type] = 3;

--- a/NPCs/Defiled/Defiled_Wisp.cs
+++ b/NPCs/Defiled/Defiled_Wisp.cs
@@ -12,9 +12,14 @@ using Terraria.ID;
 using Terraria.ModLoader;
 using static Origins.Misc.Physics;
 using ThoriumMod.Empowerments;
+using Origins.Dev;
 
 namespace Origins.NPCs.Defiled {
-	public class Defiled_Wisp : Glowing_Mod_NPC {
+	public class Defiled_Wisp : Glowing_Mod_NPC, IWikiNPC {
+		public Rectangle DrawRect => new(0, -2, 24, 26);
+		public int AnimationFrames => 24;
+		public int FrameDuration => 1;
+		public NPCExportType ImageExportType => NPCExportType.Bestiary;
 		public override void SetStaticDefaults() {
 			Main.npcFrameCount[Type] = 4;
 			NPCID.Sets.DontDoHardmodeScaling[Type] = true;

--- a/NPCs/Defiled/Enchanted_Trident.cs
+++ b/NPCs/Defiled/Enchanted_Trident.cs
@@ -1,4 +1,5 @@
-﻿using Origins.World.BiomeData;
+﻿using Origins.Dev;
+using Origins.World.BiomeData;
 using Terraria;
 using Terraria.GameContent.Bestiary;
 using Terraria.GameContent.ItemDropRules;
@@ -6,7 +7,11 @@ using Terraria.ID;
 using Terraria.ModLoader;
 
 namespace Origins.NPCs.Defiled {
-	public class Enchanted_Trident : ModNPC, IDefiledEnemy {
+	public class Enchanted_Trident : ModNPC, IDefiledEnemy, IWikiNPC {
+		public Rectangle DrawRect => new(0, 2, 76, 76);
+		public int AnimationFrames => 1;
+		public int FrameDuration => 1;
+		public NPCExportType ImageExportType => NPCExportType.Bestiary;
 		public override void Load() => this.AddBanner();
 		public override void SetStaticDefaults() {
 			Main.npcFrameCount[NPC.type] = 3;

--- a/NPCs/Defiled/Shattered_Ghoul.cs
+++ b/NPCs/Defiled/Shattered_Ghoul.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Xna.Framework;
 using Origins.Buffs;
+using Origins.Dev;
 using Origins.Items.Materials;
 using Origins.World.BiomeData;
 using Terraria;
@@ -10,7 +11,11 @@ using Terraria.ID;
 using Terraria.ModLoader;
 
 namespace Origins.NPCs.Defiled {
-	public class Shattered_Ghoul : Glowing_Mod_NPC, IDefiledEnemy {
+	public class Shattered_Ghoul : Glowing_Mod_NPC, IDefiledEnemy, IWikiNPC {
+		public Rectangle DrawRect => new(0, 6, 36, 52);
+		public int AnimationFrames => 16;
+		public int FrameDuration => 1;
+		public NPCExportType ImageExportType => NPCExportType.Bestiary;
 		public AssimilationAmount? Assimilation => 0.10f;
 		public override void SetStaticDefaults() {
 			NPCID.Sets.NPCBestiaryDrawOffset.Add(NPC.type, new NPCID.Sets.NPCBestiaryDrawModifiers() { // Influences how the NPC looks in the Bestiary

--- a/NPCs/Defiled/Shattered_Goldfish.cs
+++ b/NPCs/Defiled/Shattered_Goldfish.cs
@@ -1,11 +1,16 @@
 ﻿using Microsoft.Xna.Framework;
+using Origins.Dev;
 using Terraria;
 using Terraria.GameContent.Bestiary;
 using Terraria.ID;
 using Terraria.ModLoader;
 
 namespace Origins.NPCs.Defiled {
-	public class Shattered_Goldfish : Glowing_Mod_NPC, IDefiledEnemy {
+	public class Shattered_Goldfish : Glowing_Mod_NPC, IDefiledEnemy, IWikiNPC {
+		public Rectangle DrawRect => new(0, 0, 38, 28);
+		public int AnimationFrames => 24;
+		public int FrameDuration => 1;
+		public NPCExportType ImageExportType => NPCExportType.Bestiary;
 		public override void SetStaticDefaults() {
 			Main.npcFrameCount[NPC.type] = 6;
 			DefiledGlobalNPC.NPCTransformations.Add(NPCID.Goldfish, Type);

--- a/NPCs/Defiled/Shattered_Mummy.cs
+++ b/NPCs/Defiled/Shattered_Mummy.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Xna.Framework;
+using Origins.Dev;
 using Origins.Tiles.Defiled;
 using Origins.World.BiomeData;
 using System.IO;
@@ -10,7 +11,11 @@ using Terraria.ID;
 using Terraria.ModLoader;
 
 namespace Origins.NPCs.Defiled {
-	public class Shattered_Mummy : Glowing_Mod_NPC, IDefiledEnemy {
+	public class Shattered_Mummy : Glowing_Mod_NPC, IDefiledEnemy, IWikiNPC {
+		public Rectangle DrawRect => new(0, 4, 40, 56);
+		public int AnimationFrames => 16;
+		public int FrameDuration => 2;
+		public NPCExportType ImageExportType => NPCExportType.Bestiary;
 		public AssimilationAmount? Assimilation => 0.07f;
 		public override void SetStaticDefaults() {
 			NPCID.Sets.NPCBestiaryDrawOffset.Add(NPC.type, new NPCID.Sets.NPCBestiaryDrawModifiers() { // Influences how the NPC looks in the Bestiary

--- a/NPCs/Dungeon/Cellarkeep.cs
+++ b/NPCs/Dungeon/Cellarkeep.cs
@@ -3,6 +3,7 @@ using Microsoft.Xna.Framework.Graphics;
 using Origins.Dev;
 using Origins.Items.Weapons.Summoner;
 using Origins.Projectiles;
+using System;
 using Terraria;
 using Terraria.Audio;
 using Terraria.GameContent;
@@ -14,10 +15,11 @@ using Terraria.ModLoader.Utilities;
 
 namespace Origins.NPCs.Dungeon {
 	public class Cellarkeep : ModNPC, IWikiNPC {
-		public Rectangle DrawRect => new(0, 0, 40, 56);
-		public int AnimationFrames => 1;
+		public Rectangle DrawRect => new(0, 4, 40, 56);
+		public int AnimationFrames => 48;
 		public int FrameDuration => 1;
-		public NPCExportType ImageExportType => NPCExportType.SpriteSheet;
+		public NPCExportType ImageExportType => NPCExportType.Bestiary;
+		public Range FrameRange => new(8, 48);
 		public override void Load() => this.AddBanner();
 		public override void SetStaticDefaults() {
 			Main.npcFrameCount[NPC.type] = 18;

--- a/NPCs/Dungeon/Cellarkeep.cs
+++ b/NPCs/Dungeon/Cellarkeep.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
+using Origins.Dev;
 using Origins.Items.Weapons.Summoner;
 using Origins.Projectiles;
 using Terraria;
@@ -12,7 +13,11 @@ using Terraria.ModLoader;
 using Terraria.ModLoader.Utilities;
 
 namespace Origins.NPCs.Dungeon {
-	public class Cellarkeep : ModNPC {
+	public class Cellarkeep : ModNPC, IWikiNPC {
+		public Rectangle DrawRect => new(0, 0, 40, 56);
+		public int AnimationFrames => 1;
+		public int FrameDuration => 1;
+		public NPCExportType ImageExportType => NPCExportType.SpriteSheet;
 		public override void Load() => this.AddBanner();
 		public override void SetStaticDefaults() {
 			Main.npcFrameCount[NPC.type] = 18;
@@ -125,7 +130,11 @@ namespace Origins.NPCs.Dungeon {
 			}
 		}
 	}
-	public class Cellarkeep_Barrel : ModNPC {
+	public class Cellarkeep_Barrel : ModNPC, IWikiNPC {
+		public Rectangle DrawRect => new(0, 0, 26, 26);
+		public int AnimationFrames => 1;
+		public int FrameDuration => 1;
+		public NPCExportType ImageExportType => NPCExportType.SpriteSheet;
 		public override void SetStaticDefaults() {
 			NPCID.Sets.NPCBestiaryDrawOffset.Add(Type, new() {
 				Hide = true // Hides this NPC from the Bestiary, useful for multi-part NPCs whom you only want one entry.

--- a/NPCs/Dungeon/Etherealizer.cs
+++ b/NPCs/Dungeon/Etherealizer.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Microsoft.Xna.Framework.Graphics.PackedVector;
+using Origins.Dev;
 using Origins.Items.Weapons.Summoner;
 using Origins.Projectiles;
 using System;
@@ -18,7 +19,11 @@ using Terraria.ModLoader;
 using Terraria.ModLoader.Utilities;
 
 namespace Origins.NPCs.Dungeon {
-	public class Etherealizer : ModNPC {
+	public class Etherealizer : ModNPC, IWikiNPC {
+		public Rectangle DrawRect => new(0, 6, 32, 56);
+		public int AnimationFrames => 24;
+		public int FrameDuration => 1;
+		public NPCExportType ImageExportType => NPCExportType.Bestiary;
 		//public override void Load() => this.AddBanner();
 		protected override bool CloneNewInstances => true;
 		static public int ID { get; private set; }

--- a/NPCs/Felnum/Cloud_Elemental.cs
+++ b/NPCs/Felnum/Cloud_Elemental.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Xna.Framework.Graphics;
 using Origins.Buffs;
+using Origins.Dev;
 using Origins.Dusts;
 using Origins.Items.Armor.Felnum;
 using Origins.Items.Armor.Vanity.Other;
@@ -17,8 +18,12 @@ using Terraria.ModLoader;
 using static Terraria.Utilities.NPCUtils;
 
 namespace Origins.NPCs.Felnum {
-	public class Cloud_Elemental : ModNPC {
+	public class Cloud_Elemental : ModNPC, IWikiNPC {
 		AutoLoadingAsset<Texture2D> armTexture = typeof(Cloud_Elemental).GetDefaultTMLName() + "_Fingergun";
+		public Rectangle DrawRect => new(0, 0, 70, 46);
+		public int AnimationFrames => 16;
+		public int FrameDuration => 1;
+		public NPCExportType ImageExportType => NPCExportType.Bestiary;
 		//public override void Load() => this.AddBanner();
 		public override void SetStaticDefaults() {
 			NPCID.Sets.ShimmerTransformToNPC[NPC.type] = NPCID.DD2DarkMageT1;

--- a/NPCs/Felnum/Felnum_Einheri.cs
+++ b/NPCs/Felnum/Felnum_Einheri.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Xna.Framework.Graphics;
 using Origins;
 using Origins.Buffs;
+using Origins.Dev;
 using Origins.Dusts;
 using Origins.Items.Accessories;
 using Origins.Items.Armor.Felnum;
@@ -19,12 +20,16 @@ using Terraria.ModLoader;
 using static Terraria.Utilities.NPCUtils;
 
 namespace Origins.NPCs.Felnum {
-	public class Felnum_Einheri : ModNPC {
+	public class Felnum_Einheri : ModNPC, IWikiNPC {
 		AutoLoadingAsset<Texture2D> glowTexture = typeof(Felnum_Einheri).GetDefaultTMLName() + "_Glow";
 		AutoLoadingAsset<Texture2D> glowOverTexture = typeof(Felnum_Einheri).GetDefaultTMLName() + "_Glow_Over";
 		AutoLoadingAsset<Texture2D> attackTexture = typeof(Felnum_Einheri).GetDefaultTMLName() + "_Attac";
 		AutoLoadingAsset<Texture2D> spearTexture = typeof(Felnum_Einheri).GetDefaultTMLName() + "_Spear";
 		AutoLoadingAsset<Texture2D> spearGlowTexture = typeof(Felnum_Einheri).GetDefaultTMLName() + "_Spear_Glow";
+		public Rectangle DrawRect => new(14, -10, 82, 96);
+		public int AnimationFrames => 48;
+		public int FrameDuration => 1;
+		public NPCExportType ImageExportType => NPCExportType.Bestiary;
 		public override void Load() => this.AddBanner();
 		public override void SetStaticDefaults() {
 			NPCID.Sets.ShimmerTransformToNPC[NPC.type] = NPCID.UndeadViking;

--- a/NPCs/Felnum/Felnum_Guardian.cs
+++ b/NPCs/Felnum/Felnum_Guardian.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Xna.Framework.Graphics;
 using Origins;
 using Origins.Buffs;
+using Origins.Dev;
 using Origins.Dusts;
 using Origins.Items.Armor.Defiled;
 using Origins.Items.Armor.Felnum;
@@ -21,10 +22,13 @@ using Terraria.ModLoader;
 using static Terraria.Utilities.NPCUtils;
 
 namespace Origins.NPCs.Felnum {
-	public class Felnum_Guardian : ModNPC {
+	public class Felnum_Guardian : ModNPC, IWikiNPC {
 		AutoLoadingAsset<Texture2D> glowTexture = typeof(Felnum_Guardian).GetDefaultTMLName() + "_Glow";
 		public override void Load() => this.AddBanner();
 		public static HashSet<int> FriendlyNPCTypes { get; private set; } = [];
+		public Rectangle DrawRect => new(-14, 4, 72, 70);
+		public int AnimationFrames => 16;
+		public int FrameDuration => 1;
 		public override void SetStaticDefaults() {
 			NPCID.Sets.ShimmerTransformToNPC[NPC.type] = NPCID.FairyCritterBlue;
 			Main.npcFrameCount[NPC.type] = 4;

--- a/NPCs/Felnum/Felnum_Ore_Slime.cs
+++ b/NPCs/Felnum/Felnum_Ore_Slime.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Xna.Framework.Graphics;
 using Origins;
 using Origins.Buffs;
+using Origins.Dev;
 using Origins.Items.Armor.Felnum;
 using Origins.Reflection;
 using Origins.Tiles.Other;
@@ -18,7 +19,11 @@ using Terraria.ID;
 using Terraria.ModLoader;
 
 namespace Origins.NPCs.Felnum {
-	public class Felnum_Ore_Slime : ModNPC {
+	public class Felnum_Ore_Slime : ModNPC, IWikiNPC {
+		public Rectangle DrawRect => new(0, 0, 32, 26);
+		public int AnimationFrames => 2;
+		public int FrameDuration => 8;
+		public NPCExportType ImageExportType => NPCExportType.SpriteSheet;
 		public override void Load() => this.AddBanner();
 		public override void SetStaticDefaults() {
 			NPCID.Sets.ShimmerTransformToNPC[Type] = NPCID.ShimmerSlime;

--- a/NPCs/Fiberglass/EnchantedFiberglassWeapons.cs
+++ b/NPCs/Fiberglass/EnchantedFiberglassWeapons.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
+using Origins.Dev;
 using Origins.Items.Other.Consumables;
 using Origins.Items.Weapons.Melee;
 using Origins.Items.Weapons.Ranged;
@@ -14,9 +15,13 @@ using Terraria.Utilities;
 using static Origins.OriginExtensions;
 
 namespace Origins.NPCs.Fiberglass {
-	public class Enchanted_Fiberglass_Bow : ModNPC {
+	public class Enchanted_Fiberglass_Bow : ModNPC, IWikiNPC {
 		Color[] oldColor = new Color[10];
 		int[] oldDir = new int[10];
+		public Rectangle DrawRect => new(0, 0, 18, 36);
+		public int AnimationFrames => 1;
+		public int FrameDuration => 1;
+		public NPCExportType ImageExportType => NPCExportType.Bestiary;
 		public override void SetStaticDefaults() {
 			NPCID.Sets.TrailingMode[NPC.type] = 3;
 			NPCID.Sets.NoMultiplayerSmoothingByType[NPC.type] = true;
@@ -118,9 +123,13 @@ namespace Origins.NPCs.Fiberglass {
 			NPC.Center = options.Get();
 		}
 	}
-	public class Enchanted_Fiberglass_Pistol : ModNPC {
+	public class Enchanted_Fiberglass_Pistol : ModNPC, IWikiNPC {
 		Color[] oldColor = new Color[10];
 		int[] oldDir = new int[10];
+		public Rectangle DrawRect => new(0, 0, 38, 22);
+		public int AnimationFrames => 1;
+		public int FrameDuration => 1;
+		public NPCExportType ImageExportType => NPCExportType.SpriteSheet;
 		public override void SetStaticDefaults() {
 			NPCID.Sets.TrailingMode[NPC.type] = 3;
 			NPCID.Sets.NoMultiplayerSmoothingByType[NPC.type] = true;
@@ -198,11 +207,15 @@ namespace Origins.NPCs.Fiberglass {
 			oldColor[0] = drawColor;
 		}
 	}
-	public class Enchanted_Fiberglass_Sword : ModNPC {
+	public class Enchanted_Fiberglass_Sword : ModNPC, IWikiNPC {
 		Color[] oldColor = new Color[10];
 		int[] oldDir = new int[10];
 		int stuck = 0;
 		Vector2 stuckVel = Vector2.Zero;
+		public Rectangle DrawRect => new(0, 0, 44, 48);
+		public int AnimationFrames => 1;
+		public int FrameDuration => 1;
+		public NPCExportType ImageExportType => NPCExportType.SpriteSheet;
 		public override void SetStaticDefaults() {
 			NPCID.Sets.TrailingMode[NPC.type] = 3;
 		}

--- a/NPCs/Fiberglass/Enchanted_Fiberglass_Cannon.cs
+++ b/NPCs/Fiberglass/Enchanted_Fiberglass_Cannon.cs
@@ -21,11 +21,16 @@ using ThoriumMod.Empowerments;
 using Terraria.Audio;
 using Origins.Dusts;
 using Newtonsoft.Json.Linq;
+using Origins.Dev;
 
 namespace Origins.NPCs.Fiberglass {
-	public class Enchanted_Fiberglass_Cannon : ModNPC {
+	public class Enchanted_Fiberglass_Cannon : ModNPC, IWikiNPC {
 		readonly Color[] oldColor = new Color[10];
 		readonly int[] oldDir = new int[10];
+		public Rectangle DrawRect => new(0, 0, 52, 26);
+		public int AnimationFrames => 1;
+		public int FrameDuration => 1;
+		public NPCExportType ImageExportType => NPCExportType.SpriteSheet;
 		public override void SetStaticDefaults() {
 			NPCID.Sets.TrailingMode[NPC.type] = 3;
 		}

--- a/NPCs/Fiberglass/Fiberglass_Weaver.cs
+++ b/NPCs/Fiberglass/Fiberglass_Weaver.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
+using Origins.Dev;
 using Origins.Items.Accessories;
 using Origins.Items.Armor.Fiberglass;
 using Origins.Items.Armor.Vanity.BossMasks;
@@ -28,7 +29,7 @@ using static Tyfyter.Utils.KinematicUtils;
 
 namespace Origins.NPCs.Fiberglass {
 	[AutoloadBossHead]
-	public class Fiberglass_Weaver : ModNPC, IMeleeCollisionDataNPC {
+	public class Fiberglass_Weaver : ModNPC, IMeleeCollisionDataNPC, ICustomWikiStat {
 		static AutoLoadingAsset<Texture2D> UpperLegTexture = "Origins/NPCs/Fiberglass/Fiberglass_Weaver_Leg_Upper";
 		static AutoLoadingAsset<Texture2D> LowerLegTexture = "Origins/NPCs/Fiberglass/Fiberglass_Weaver_Leg_Lower";
 		Arm[] legs;
@@ -40,6 +41,7 @@ namespace Origins.NPCs.Fiberglass {
 		const float totalLegLength = upperLegLength + lowerLegLength;
 		Vector2? spawnPosition = null;
 		public static int DifficultyMult => Main.masterMode ? 3 : (Main.expertMode ? 2 : 1);
+		string ICustomWikiStat.CustomSpritePath => WikiPageExporter.GetWikiImagePath("UI/Fiberglass_Weaver_Preview");
 		public override void SetStaticDefaults() {
 			NPCID.Sets.CantTakeLunchMoney[Type] = false;
 			NPCID.Sets.MPAllowedEnemies[Type] = true;

--- a/NPCs/MiscE/Buckethead_Zombie.cs
+++ b/NPCs/MiscE/Buckethead_Zombie.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Xna.Framework;
+using Origins.Dev;
 using Terraria;
 using Terraria.GameContent.Bestiary;
 using Terraria.GameContent.ItemDropRules;
@@ -6,7 +7,11 @@ using Terraria.ID;
 using Terraria.ModLoader;
 
 namespace Origins.NPCs.MiscE {
-    public class Buckethead_Zombie : ModNPC {
+    public class Buckethead_Zombie : ModNPC, IWikiNPC {
+		public Rectangle DrawRect => new(0, 6, 34, 46);
+		public int AnimationFrames => 24;
+		public int FrameDuration => 1;
+		public NPCExportType ImageExportType => NPCExportType.Bestiary;
 		public override void SetStaticDefaults() {
 			NPCID.Sets.ShimmerTransformToNPC[NPC.type] = NPCID.UndeadMiner;//maybe undead viking instead?
 			Main.npcFrameCount[NPC.type] = 3;

--- a/NPCs/MiscE/Conehead_Zombie.cs
+++ b/NPCs/MiscE/Conehead_Zombie.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Xna.Framework;
+using Origins.Dev;
 using Origins.Tiles.Other;
 using Terraria;
 using Terraria.GameContent.Bestiary;
@@ -7,7 +8,11 @@ using Terraria.ID;
 using Terraria.ModLoader;
 
 namespace Origins.NPCs.MiscE {
-    public class Conehead_Zombie : ModNPC {
+    public class Conehead_Zombie : ModNPC, IWikiNPC {
+		public Rectangle DrawRect => new(0, 6, 34, 56);
+		public int AnimationFrames => 24;
+		public int FrameDuration => 1;
+		public NPCExportType ImageExportType => NPCExportType.Bestiary;
 		public override void SetStaticDefaults() {
 			NPCID.Sets.ShimmerTransformToNPC[NPC.type] = NPCID.Tim;
 			Main.npcFrameCount[NPC.type] = 3;

--- a/NPCs/MiscE/Cranivore.cs
+++ b/NPCs/MiscE/Cranivore.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Origins.Buffs;
+using Origins.Dev;
 using PegasusLib;
 using System;
 using Terraria;
@@ -11,7 +12,11 @@ using Terraria.ID;
 using Terraria.ModLoader;
 
 namespace Origins.NPCs.MiscE {
-    public class Cranivore : ModNPC {
+    public class Cranivore : ModNPC, IWikiNPC {
+		public Rectangle DrawRect => new(0, 0, 18, 34);
+		public int AnimationFrames => 1;
+		public int FrameDuration => 1;
+		public NPCExportType ImageExportType => NPCExportType.SpriteSheet;
 		public static new AutoCastingAsset<Texture2D> HeadTexture { get; private set; }
 		public override void SetStaticDefaults() {
 			Main.npcFrameCount[Type] = 2;

--- a/NPCs/MiscE/Crimbrain.cs
+++ b/NPCs/MiscE/Crimbrain.cs
@@ -1,4 +1,5 @@
 ﻿using Origins.Buffs;
+using Origins.Dev;
 using Origins.Items.Weapons.Summoner;
 using System;
 using Terraria;
@@ -8,7 +9,11 @@ using Terraria.ID;
 using Terraria.ModLoader;
 
 namespace Origins.NPCs.MiscE {
-	public class Crimbrain : ModNPC {
+	public class Crimbrain : ModNPC, IWikiNPC {
+		public Rectangle DrawRect => new(0, 36, 34, 28);
+		public int AnimationFrames => 32;
+		public int FrameDuration => 1;
+		public NPCExportType ImageExportType => NPCExportType.Bestiary;
 		public override void Load() => this.AddBanner();
 		public override void SetStaticDefaults() {
 			Main.npcFrameCount[NPC.type] = 4;

--- a/NPCs/MiscE/Fae_Nymph.cs
+++ b/NPCs/MiscE/Fae_Nymph.cs
@@ -48,7 +48,11 @@ namespace Origins.NPCs.MiscE {
 			}
 		}
 	}
-	public class Whimsical_Girl : ModNPC {
+	public class Whimsical_Girl : ModNPC, IWikiNPC {
+		public Rectangle DrawRect => new(0, 4, 38, 54);
+		public int AnimationFrames => 1;
+		public int FrameDuration => 1;
+		public NPCExportType ImageExportType => NPCExportType.Bestiary;
 		public override void SetStaticDefaults() {
 			NPCID.Sets.ShimmerTransformToNPC[NPCID.LostGirl] = Type;
 			Main.npcFrameCount[Type] = 9;

--- a/NPCs/MiscE/Fae_Nymph.cs
+++ b/NPCs/MiscE/Fae_Nymph.cs
@@ -1,4 +1,5 @@
-﻿using Origins.Items.Accessories;
+﻿using Origins.Dev;
+using Origins.Items.Accessories;
 using Terraria;
 using Terraria.GameContent.Bestiary;
 using Terraria.GameContent.ItemDropRules;
@@ -6,7 +7,11 @@ using Terraria.ID;
 using Terraria.ModLoader;
 
 namespace Origins.NPCs.MiscE {
-	public class Fae_Nymph : ModNPC {
+	public class Fae_Nymph : ModNPC, IWikiNPC {
+		public Rectangle DrawRect => new(0, 4, 38, 54);
+		public int AnimationFrames => 36;
+		public int FrameDuration => 1;
+		public NPCExportType ImageExportType => NPCExportType.Bestiary;
 		public override void SetStaticDefaults() {
 			NPCID.Sets.ShimmerTransformToNPC[NPCID.Nymph] = Type;
 			Main.npcFrameCount[Type] = Main.npcFrameCount[NPCID.Nymph];

--- a/NPCs/MiscE/Graveshield_Zombie.cs
+++ b/NPCs/MiscE/Graveshield_Zombie.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Xna.Framework;
+using Origins.Dev;
 using Origins.Tiles.Other;
 using System;
 using Terraria;
@@ -9,7 +10,11 @@ using Terraria.Localization;
 using Terraria.ModLoader;
 
 namespace Origins.NPCs.MiscE {
-    public class Graveshield_Zombie : ModNPC {
+    public class Graveshield_Zombie : ModNPC, IWikiNPC {
+		public Rectangle DrawRect => new(2, 6, 36, 48);
+		public int AnimationFrames => 24;
+		public int FrameDuration => 1;
+		public NPCExportType ImageExportType => NPCExportType.Bestiary;
 		public override void SetStaticDefaults() {
 			NPCID.Sets.ShimmerTransformToNPC[NPC.type] = NPCID.BoneThrowingSkeleton;
 			Main.npcFrameCount[NPC.type] = 3;

--- a/NPCs/MiscE/Graveshield_Zombie.cs
+++ b/NPCs/MiscE/Graveshield_Zombie.cs
@@ -50,7 +50,8 @@ namespace Origins.NPCs.MiscE {
 			bestiaryEntry.AddTags(
 				this.GetBestiaryFlavorText(),
 				BestiaryDatabaseNPCsPopulator.CommonTags.SpawnConditions.Biomes.Graveyard,
-				BestiaryDatabaseNPCsPopulator.CommonTags.SpawnConditions.Times.NightTime
+				BestiaryDatabaseNPCsPopulator.CommonTags.SpawnConditions.Times.NightTime,
+				BestiaryDatabaseNPCsPopulator.CommonTags.SpawnConditions.Biomes.Surface
 			);
 		}
 		public override void ModifyNPCLoot(NPCLoot npcLoot) {

--- a/NPCs/MiscE/Optiphage.cs
+++ b/NPCs/MiscE/Optiphage.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Origins.Buffs;
+using Origins.Dev;
 using Origins.Items.Weapons.Summoner;
 using System;
 using Terraria;
@@ -11,7 +12,11 @@ using Terraria.ID;
 using Terraria.ModLoader;
 
 namespace Origins.NPCs.MiscE {
-    public class Optiphage : ModNPC {
+    public class Optiphage : ModNPC, IWikiNPC {
+		public Rectangle DrawRect => new(0, 0, 16, 30);
+		public int AnimationFrames => 2;
+		public int FrameDuration => 8;
+		public NPCExportType ImageExportType => NPCExportType.SpriteSheet;
 		public static new AutoCastingAsset<Texture2D> HeadTexture { get; private set; }
 		public override void SetStaticDefaults() {
 			Main.npcFrameCount[Type] = 2;

--- a/NPCs/MiscE/Quests/A_Christmas_Carol.cs
+++ b/NPCs/MiscE/Quests/A_Christmas_Carol.cs
@@ -1,4 +1,5 @@
-﻿using Origins.Questing;
+﻿using Origins.Dev;
+using Origins.Questing;
 using PegasusLib;
 using System;
 using System.Collections.Generic;
@@ -10,7 +11,11 @@ using Terraria.Localization;
 using Terraria.ModLoader;
 
 namespace Origins.NPCs.MiscE.Quests {
-	public class Jacob_Marley : ModNPC {
+	public class Jacob_Marley : ModNPC, IWikiNPC {
+		public Rectangle DrawRect => new(0, 4, 40, 56);
+		public int AnimationFrames => 24;
+		public int FrameDuration => 1;
+		public NPCExportType ImageExportType => NPCExportType.Bestiary;
 		public override string Texture => "Terraria/Images/NPC_" + NPCID.Ghost;
 		public override void SetStaticDefaults() {
 			Main.npcFrameCount[NPC.type] = Main.npcFrameCount[NPCID.Ghost];
@@ -73,7 +78,11 @@ namespace Origins.NPCs.MiscE.Quests {
 			);
 		}
 	}
-	public class Spirit_Of_Christmas_Past : ModNPC {
+	public class Spirit_Of_Christmas_Past : ModNPC, IWikiNPC {
+		public Rectangle DrawRect => new(0, 0, 48, 34);
+		public int AnimationFrames => 16;
+		public int FrameDuration => 1;
+		public NPCExportType ImageExportType => NPCExportType.Bestiary;
 		public override void SetStaticDefaults() {
 			Main.npcFrameCount[NPC.type] = Main.npcFrameCount[NPCID.FairyCritterBlue];
 			NPCID.Sets.NPCBestiaryDrawOffset[Type] = NPCExtensions.BestiaryWalkLeft;
@@ -137,7 +146,11 @@ namespace Origins.NPCs.MiscE.Quests {
 			}
 		}
 	}
-	public class Spirit_Of_Christmas_Present_Tax_Collector : ModNPC {
+	public class Spirit_Of_Christmas_Present_Tax_Collector : ModNPC, IWikiNPC {
+		public Rectangle DrawRect => new(0, 0, 42, 56);
+		public int AnimationFrames => 16;
+		public int FrameDuration => 2;
+		public NPCExportType ImageExportType => NPCExportType.Bestiary;
 		public override string Texture => "Terraria/Images/NPC_" + NPCID.TaxCollector;
 		public override void SetStaticDefaults() {
 			Main.npcFrameCount[NPC.type] = Main.npcFrameCount[NPCID.TaxCollector];
@@ -175,7 +188,11 @@ namespace Origins.NPCs.MiscE.Quests {
 			return Main.dayTime;
 		}
 	}
-	public class Spirit_Of_Christmas_Present : ModNPC {
+	public class Spirit_Of_Christmas_Present : ModNPC, IWikiNPC {
+		public Rectangle DrawRect => new(0, 0, 40, 56);
+		public int AnimationFrames => 16;
+		public int FrameDuration => 2;
+		public NPCExportType ImageExportType => NPCExportType.Bestiary;
 		public override string Texture => "Terraria/Images/TownNPCs/Shimmered/Santa_Default_Party";
 		public override void SetStaticDefaults() {
 			Main.npcFrameCount[NPC.type] = Main.npcFrameCount[NPCID.SantaClaus];
@@ -333,7 +350,11 @@ namespace Origins.NPCs.MiscE.Quests {
 			if (++NPC.alpha >= 255) NPC.active = false;
 		}
 	}
-	public class Spirit_Of_Christmas_Future : ModNPC {
+	public class Spirit_Of_Christmas_Future : ModNPC, IWikiNPC {
+		public Rectangle DrawRect => new(0, 0, 26, 50);
+		public int AnimationFrames => 16;
+		public int FrameDuration => 1;
+		public NPCExportType ImageExportType => NPCExportType.Bestiary;
 		public override string Texture => "Terraria/Images/NPC_" + NPCID.Wraith;
 		public override void SetStaticDefaults() {
 			Main.npcFrameCount[NPC.type] = Main.npcFrameCount[NPCID.Wraith];

--- a/NPCs/MiscE/Slime_Worm.cs
+++ b/NPCs/MiscE/Slime_Worm.cs
@@ -17,6 +17,7 @@ using ThoriumMod.Items.HealerItems;
 
 namespace Origins.NPCs.MiscE {
 	public class Slime_Worm_Head : WormHead, ICustomWikiStat {
+		string ICustomWikiStat.CustomSpritePath => WikiPageExporter.GetWikiImagePath("UI/Slime_Worm_Preview");
 		public override int BodyType => ModContent.NPCType<Slime_Worm_Body>();
 		public override int TailType => ModContent.NPCType<Slime_Worm_Tail>();
 		//public override void Load() => this.AddBanner();

--- a/NPCs/Riven/Amebic_Slime.cs
+++ b/NPCs/Riven/Amebic_Slime.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Xna.Framework;
+using Origins.Dev;
 using Origins.Items.Weapons.Demolitionist;
 using Origins.World.BiomeData;
 using Terraria;
@@ -8,8 +9,12 @@ using Terraria.ID;
 using Terraria.ModLoader;
 
 namespace Origins.NPCs.Riven {
-	public class Amebic_Slime : ModNPC, IRivenEnemy {
+	public class Amebic_Slime : ModNPC, IRivenEnemy, IWikiNPC {
 		public AssimilationAmount? Assimilation => 0.04f;
+		public Rectangle DrawRect => new(0, 0, 32, 28);
+		public int AnimationFrames => 2;
+		public int FrameDuration => 8;
+		public NPCExportType ImageExportType => NPCExportType.SpriteSheet;
 		public override void Load() => this.AddBanner();
 		public override void SetStaticDefaults() {
 			Main.npcFrameCount[NPC.type] = 2;

--- a/NPCs/Riven/Amoeba_Bugger.cs
+++ b/NPCs/Riven/Amoeba_Bugger.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Xna.Framework;
+using Origins.Dev;
 using Origins.World.BiomeData;
 using System;
 using Terraria;
@@ -9,9 +10,11 @@ using Terraria.ID;
 using Terraria.ModLoader;
 
 namespace Origins.NPCs.Riven {
-	public class Amoeba_Bugger : Glowing_Mod_NPC, IRivenEnemy {
+	public class Amoeba_Bugger : Glowing_Mod_NPC, IRivenEnemy, IWikiNPC {
 		public override Color? GetGlowColor(Color drawColor) => Riven_Hive.GetGlowAlpha(drawColor);
 		public AssimilationAmount? Assimilation => 0.03f;
+		public Rectangle DrawRect => new(0, 0, 28, 26);
+		public int AnimationFrames => 1;
 		public override void SetStaticDefaults() {
 			NPCID.Sets.NPCBestiaryDrawOffset.Add(Type, NPCExtensions.HideInBestiary);
 			Main.npcFrameCount[NPC.type] = 2;

--- a/NPCs/Riven/Amoebeye.cs
+++ b/NPCs/Riven/Amoebeye.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Origins.Buffs;
+using Origins.Dev;
 using Origins.Gores.NPCs;
 using Origins.Items.Materials;
 using Origins.World.BiomeData;
@@ -14,7 +15,11 @@ using Terraria.ID;
 using Terraria.ModLoader;
 
 namespace Origins.NPCs.Riven {
-	public class Amoebeye : ModNPC, IRivenEnemy {
+	public class Amoebeye : ModNPC, IRivenEnemy, IWikiNPC {
+		public Rectangle DrawRect => new(0, 0, 72, 68);
+		public int AnimationFrames => 32;
+		public int FrameDuration => 1;
+		public NPCExportType ImageExportType => NPCExportType.Bestiary;
 		public AssimilationAmount? Assimilation => 0.04f;
 		public static int ID { get; private set; }
 		public override void Load() => this.AddBanner();
@@ -141,7 +146,11 @@ namespace Origins.NPCs.Riven {
 			Glowing_Mod_NPC.DrawGlow(spriteBatch, screenPos, glowTexture, NPC, Riven_Hive.GetGlowAlpha(drawColor));
 		}
 	}
-	public class Amoebeye_P : ModNPC, IRivenEnemy {
+	public class Amoebeye_P : ModNPC, IRivenEnemy, IWikiNPC {
+		public Rectangle DrawRect => new(0, 0, 58, 60);
+		public int AnimationFrames => 4;
+		public int FrameDuration => 8;
+		public NPCExportType ImageExportType => NPCExportType.SpriteSheet;
 		public static int ID { get; private set; }
 		public override void SetStaticDefaults() {
 			Main.npcFrameCount[Type] = 4;

--- a/NPCs/Riven/Barnacle_Bunny.cs
+++ b/NPCs/Riven/Barnacle_Bunny.cs
@@ -1,11 +1,16 @@
 ﻿using Microsoft.Xna.Framework;
+using Origins.Dev;
 using Origins.World.BiomeData;
 using Terraria;
 using Terraria.GameContent.Bestiary;
 using Terraria.ID;
 
 namespace Origins.NPCs.Riven {
-	public class Barnacle_Bunny : Glowing_Mod_NPC, IRivenEnemy {
+	public class Barnacle_Bunny : Glowing_Mod_NPC, IRivenEnemy, IWikiNPC {
+		public Rectangle DrawRect => new(-2, 6, 32, 32);
+		public int AnimationFrames => 28;
+		public int FrameDuration => 1;
+		public NPCExportType ImageExportType => NPCExportType.Bestiary;
 		public override Color? GetGlowColor(Color drawColor) => Riven_Hive.GetGlowAlpha(drawColor);
 		public override void Load() => this.AddBanner();
 		public override void SetStaticDefaults() {

--- a/NPCs/Riven/Barnacle_Mound.cs
+++ b/NPCs/Riven/Barnacle_Mound.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
+using Origins.Dev;
 using Origins.Items.Materials;
 using Origins.NPCs.Critters;
 using Origins.World.BiomeData;
@@ -15,10 +16,14 @@ using Terraria.ID;
 using Terraria.ModLoader;
 
 namespace Origins.NPCs.Riven {
-	public class Barnacle_Mound : ModNPC, IRivenEnemy {
+	public class Barnacle_Mound : ModNPC, IRivenEnemy, IWikiNPC {
 		//public override void Load() => this.AddBanner(); //TODO: missing banner
 		private Asset<Texture2D> _glowTexture;
 		public Texture2D GlowTexture => (_glowTexture ??= (ModContent.RequestIfExists<Texture2D>(Texture + "_Glow", out var asset) ? asset : null))?.Value;
+		public Rectangle DrawRect => new(0, -41, 34, 22);
+		public int AnimationFrames => 1;
+		public int FrameDuration => 1;
+		public NPCExportType ImageExportType => NPCExportType.Bestiary;
 		public override void SetStaticDefaults() {
 			NPCID.Sets.NPCBestiaryDrawOffset[Type] = new NPCID.Sets.NPCBestiaryDrawModifiers() {
 				Position = new(0, 20),

--- a/NPCs/Riven/Barnacleback.cs
+++ b/NPCs/Riven/Barnacleback.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Xna.Framework;
+using Origins.Dev;
 using Origins.Items.Armor.Riven;
 using Origins.Items.Materials;
 using Origins.Items.Weapons.Magic;
@@ -10,7 +11,11 @@ using Terraria.ID;
 using Terraria.ModLoader;
 
 namespace Origins.NPCs.Riven {
-	public class Barnacleback : Glowing_Mod_NPC, IRivenEnemy {
+	public class Barnacleback : Glowing_Mod_NPC, IRivenEnemy, IWikiNPC {
+		public Rectangle DrawRect => new(0, 0, 36, 50);
+		public int AnimationFrames => 24;
+		public int FrameDuration => 1;
+		public NPCExportType ImageExportType => NPCExportType.Bestiary;
 		public override Color? GetGlowColor(Color drawColor) => Riven_Hive.GetGlowAlpha(drawColor);
 		public AssimilationAmount? Assimilation => 0.05f;
 		public override void Load() => this.AddBanner();

--- a/NPCs/Riven/Bottomfeeder.cs
+++ b/NPCs/Riven/Bottomfeeder.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Xna.Framework;
+using Origins.Dev;
 using Origins.World.BiomeData;
 using Terraria;
 using Terraria.GameContent.Bestiary;
@@ -6,7 +7,11 @@ using Terraria.ID;
 using Terraria.ModLoader;
 
 namespace Origins.NPCs.Riven {
-	public class Bottomfeeder : Glowing_Mod_NPC, IRivenEnemy {
+	public class Bottomfeeder : Glowing_Mod_NPC, IRivenEnemy, IWikiNPC {
+		public Rectangle DrawRect => new(2, -4, 30, 28);
+		public int AnimationFrames => 24;
+		public int FrameDuration => 1;
+		public NPCExportType ImageExportType => NPCExportType.Bestiary;
 		public override Color? GetGlowColor(Color drawColor) => Riven_Hive.GetGlowAlpha(drawColor);
 		public override void Load() => this.AddBanner();
 		public override void SetStaticDefaults() {

--- a/NPCs/Riven/Flagellant.cs
+++ b/NPCs/Riven/Flagellant.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Xna.Framework;
+using Origins.Dev;
 using Origins.Items.Armor.Riven;
 using Origins.Items.Other.Consumables.Food;
 using Origins.Items.Weapons.Summoner;
@@ -10,7 +11,11 @@ using Terraria.ID;
 using Terraria.ModLoader;
 
 namespace Origins.NPCs.Riven {
-    public class Flagellant : Glowing_Mod_NPC, IRivenEnemy {
+    public class Flagellant : Glowing_Mod_NPC, IRivenEnemy, IWikiNPC {
+		public Rectangle DrawRect => new(0, 0, 56, 60);
+		public int AnimationFrames => 24;
+		public int FrameDuration => 1;
+		public NPCExportType ImageExportType => NPCExportType.Bestiary;
 		public override Color? GetGlowColor(Color drawColor) => Riven_Hive.GetGlowAlpha(drawColor);
 		public AssimilationAmount? Assimilation => 0.11f;
 		public override void Load() => this.AddBanner();

--- a/NPCs/Riven/Pustule_Jelly.cs
+++ b/NPCs/Riven/Pustule_Jelly.cs
@@ -14,9 +14,14 @@ using Terraria.Audio;
 using Origins.Projectiles;
 using Origins.Gores.NPCs;
 using Origins.Buffs;
+using Origins.Dev;
 
 namespace Origins.NPCs.Riven {
-	public class Pustule_Jelly : Glowing_Mod_NPC, IRivenEnemy {
+	public class Pustule_Jelly : Glowing_Mod_NPC, IRivenEnemy, IWikiNPC {
+		public Rectangle DrawRect => new(0, 0, 32, 42);
+		public int AnimationFrames => 24;
+		public int FrameDuration => 1;
+		public NPCExportType ImageExportType => NPCExportType.Bestiary;
 		public override Color? GetGlowColor(Color drawColor) => Riven_Hive.GetGlowAlpha(drawColor);
 		public AssimilationAmount? Assimilation => 0.08f;
 		public override void Load() => this.AddBanner();

--- a/NPCs/Riven/Riven_Fighter.cs
+++ b/NPCs/Riven/Riven_Fighter.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Xna.Framework;
+using Origins.Dev;
 using Origins.Items.Accessories;
 using Origins.Items.Armor.Riven;
 using Origins.Items.Materials;
@@ -12,7 +13,11 @@ using Terraria.ID;
 using Terraria.ModLoader;
 
 namespace Origins.NPCs.Riven {
-	public class Riven_Fighter : Glowing_Mod_NPC, IRivenEnemy {
+	public class Riven_Fighter : Glowing_Mod_NPC, IRivenEnemy, IWikiNPC {
+		public Rectangle DrawRect => new(0, 6, 36, 40);
+		public int AnimationFrames => 32;
+		public int FrameDuration => 1;
+		public NPCExportType ImageExportType => NPCExportType.Bestiary;
 		public override Color? GetGlowColor(Color drawColor) => Riven_Hive.GetGlowAlpha(drawColor);
 		public AssimilationAmount? Assimilation => 0.09f;
 		public override void Load() => this.AddBanner();

--- a/NPCs/Riven/Riven_Mimic.cs
+++ b/NPCs/Riven/Riven_Mimic.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Xna.Framework;
+using Origins.Dev;
 using Origins.Items.Accessories;
 using Origins.Items.Tools;
 using Origins.Items.Weapons.Magic;
@@ -11,7 +12,11 @@ using Terraria.ID;
 using Terraria.ModLoader;
 
 namespace Origins.NPCs.Riven {
-	public class Riven_Mimic : Glowing_Mod_NPC, IRivenEnemy {
+	public class Riven_Mimic : Glowing_Mod_NPC, IRivenEnemy, IWikiNPC {
+		public Rectangle DrawRect => new(0, 4, 60, 50);
+		public int AnimationFrames => 1;
+		public int FrameDuration => 1;
+		public NPCExportType ImageExportType => NPCExportType.Bestiary;
 		public override Color? GetGlowColor(Color drawColor) => Riven_Hive.GetGlowAlpha(drawColor);
 		public override void Load() => this.AddBanner();
 		public override void SetStaticDefaults() {

--- a/NPCs/Riven/Riven_Mummy.cs
+++ b/NPCs/Riven/Riven_Mummy.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Xna.Framework;
+using Origins.Dev;
 using Origins.Tiles.Riven;
 using Origins.World.BiomeData;
 using Terraria;
@@ -9,7 +10,11 @@ using Terraria.ModLoader;
 using Terraria.ModLoader.Utilities;
 
 namespace Origins.NPCs.Riven {
-	public class Riven_Mummy : Glowing_Mod_NPC, IRivenEnemy {
+	public class Riven_Mummy : Glowing_Mod_NPC, IRivenEnemy, IWikiNPC {
+		public Rectangle DrawRect => new(0, 6, 40, 48);
+		public int AnimationFrames => 16;
+		public int FrameDuration => 2;
+		public NPCExportType ImageExportType => NPCExportType.Bestiary;
 		public override Color? GetGlowColor(Color drawColor) => Riven_Hive.GetGlowAlpha(drawColor);
 		public AssimilationAmount? Assimilation => 0.07f;
 		public override void Load() => this.AddBanner();

--- a/NPCs/Riven/Riven_Penguin.cs
+++ b/NPCs/Riven/Riven_Penguin.cs
@@ -1,11 +1,16 @@
 ﻿using Microsoft.Xna.Framework;
+using Origins.Dev;
 using Origins.World.BiomeData;
 using Terraria;
 using Terraria.GameContent.Bestiary;
 using Terraria.ID;
 
 namespace Origins.NPCs.Riven {
-	public class Riven_Penguin : Glowing_Mod_NPC, IRivenEnemy {
+	public class Riven_Penguin : Glowing_Mod_NPC, IRivenEnemy, IWikiNPC {
+		public Rectangle DrawRect => new(0, 4, 32, 40);
+		public int AnimationFrames => 24;
+		public int FrameDuration => 1;
+		public NPCExportType ImageExportType => NPCExportType.Bestiary;
 		public override Color? GetGlowColor(Color drawColor) => Riven_Hive.GetGlowAlpha(drawColor);
 		public override void Load() => this.AddBanner();
 		public override void SetStaticDefaults() {

--- a/NPCs/Riven/Riven_Pigron.cs
+++ b/NPCs/Riven/Riven_Pigron.cs
@@ -16,6 +16,7 @@ namespace Origins.NPCs.Riven {
 			data["Name"] = "Riven Pigron";
 		}
 		string ICustomWikiStat.CustomStatPath => "Riven_Pigron";
+		string ICustomWikiStat.CustomSpritePath => "Riven_Pigron";
 		public override Color? GetGlowColor(Color drawColor) => Riven_Hive.GetGlowAlpha(drawColor);
 		public override void SetStaticDefaults() {
 			Main.npcFrameCount[Type] = Main.npcFrameCount[NPCID.PigronCrimson];

--- a/NPCs/Riven/Riven_Pigron.cs
+++ b/NPCs/Riven/Riven_Pigron.cs
@@ -1,4 +1,6 @@
 ﻿using Microsoft.Xna.Framework;
+using Newtonsoft.Json.Linq;
+using Origins.Dev;
 using Origins.Items.Accessories;
 using Origins.Items.Weapons.Ranged;
 using Origins.World.BiomeData;
@@ -9,7 +11,11 @@ using Terraria.ID;
 using Terraria.ModLoader;
 
 namespace Origins.NPCs.Riven {
-	public class Riven_Pigron : Glowing_Mod_NPC, IRivenEnemy {
+	public class Riven_Pigron : Glowing_Mod_NPC, IRivenEnemy, ICustomWikiStat {
+		void ICustomWikiStat.ModifyWikiStats(JObject data) {
+			data["Name"] = "Riven Pigron";
+		}
+		string ICustomWikiStat.CustomStatPath => "Riven_Pigron";
 		public override Color? GetGlowColor(Color drawColor) => Riven_Hive.GetGlowAlpha(drawColor);
 		public override void SetStaticDefaults() {
 			Main.npcFrameCount[Type] = Main.npcFrameCount[NPCID.PigronCrimson];

--- a/NPCs/Riven/Riven_Pigron.cs
+++ b/NPCs/Riven/Riven_Pigron.cs
@@ -11,7 +11,11 @@ using Terraria.ID;
 using Terraria.ModLoader;
 
 namespace Origins.NPCs.Riven {
-	public class Riven_Pigron : Glowing_Mod_NPC, IRivenEnemy, ICustomWikiStat {
+	public class Riven_Pigron : Glowing_Mod_NPC, IRivenEnemy, ICustomWikiStat, IWikiNPC {
+		public Rectangle DrawRect => new(-8, 16, 80, 66);
+		public int AnimationFrames => 56;
+		public int FrameDuration => 1;
+		public NPCExportType ImageExportType => NPCExportType.Bestiary;
 		void ICustomWikiStat.ModifyWikiStats(JObject data) {
 			data["Name"] = "Riven Pigron";
 		}

--- a/NPCs/Riven/Rivenator.cs
+++ b/NPCs/Riven/Rivenator.cs
@@ -17,6 +17,7 @@ namespace Origins.NPCs.Riven {
 	/// TODO: use <see cref="Worm"/>
 	/// </summary>
 	public class Rivenator_Head : Rivenator, ICustomWikiStat {
+		string ICustomWikiStat.CustomSpritePath => WikiPageExporter.GetWikiImagePath("UI/Rivenator_Preview");
 		public override void Load() => this.AddBanner();
 		public override void SetStaticDefaults() {
 			NPCID.Sets.NPCBestiaryDrawOffset[Type] = new NPCID.Sets.NPCBestiaryDrawModifiers() { // Influences how the NPC looks in the Bestiary
@@ -103,7 +104,8 @@ namespace Origins.NPCs.Riven {
 		}
 	}
 
-	internal class Rivenator_Body : Rivenator {
+	internal class Rivenator_Body : Rivenator, ICustomWikiStat {
+		string ICustomWikiStat.CustomStatPath => ModContent.GetInstance<NPCWikiProvider>().PageName(this) + "_Body";
 		public override void SetStaticDefaults() {
 			base.SetStaticDefaults();
 			NPCID.Sets.NPCBestiaryDrawOffset.Add(Type, NPCExtensions.HideInBestiary);
@@ -113,7 +115,8 @@ namespace Origins.NPCs.Riven {
 		}
 	}
 
-	internal class Rivenator_Tail : Rivenator {
+	internal class Rivenator_Tail : Rivenator, ICustomWikiStat {
+		string ICustomWikiStat.CustomStatPath => ModContent.GetInstance<NPCWikiProvider>().PageName(this) + "_Tail";
 		public override void SetStaticDefaults() {
 			base.SetStaticDefaults();
 			NPCID.Sets.NPCBestiaryDrawOffset.Add(Type, NPCExtensions.HideInBestiary);

--- a/NPCs/Riven/Savage_Whip.cs
+++ b/NPCs/Riven/Savage_Whip.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
+using Origins.Dev;
 using Origins.World.BiomeData;
 using PegasusLib;
 using System;
@@ -10,7 +11,8 @@ using Terraria.ID;
 using Terraria.ModLoader;
 
 namespace Origins.NPCs.Riven {
-	public class Savage_Whip : ModNPC, IRivenEnemy {
+	public class Savage_Whip : ModNPC, IRivenEnemy, ICustomWikiStat {
+		string ICustomWikiStat.CustomSpritePath => WikiPageExporter.GetWikiImagePath("UI/Savage_Whip_Preview");
 		public override void Load() {
 			this.AddBanner();
 			On_NPC.AddBuff += On_NPC_AddBuff;

--- a/NPCs/Riven/Single_Cellular_Nautilus.cs
+++ b/NPCs/Riven/Single_Cellular_Nautilus.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Xna.Framework;
+using Origins.Dev;
 using Origins.Items.Armor.Riven;
 using Origins.Items.Materials;
 using Origins.World.BiomeData;
@@ -10,7 +11,11 @@ using Terraria.ID;
 using Terraria.ModLoader;
 
 namespace Origins.NPCs.Riven {
-	public class Single_Cellular_Nautilus : Glowing_Mod_NPC, IRivenEnemy {
+	public class Single_Cellular_Nautilus : Glowing_Mod_NPC, IRivenEnemy, IWikiNPC {
+		public Rectangle DrawRect => new(0, 6, 38, 30);
+		public int AnimationFrames => 1;
+		public int FrameDuration => 1;
+		public NPCExportType ImageExportType => NPCExportType.Bestiary;
 		public AssimilationAmount? Assimilation => 0.03f;
 		public override void Load() => this.AddBanner();
 		public override void SetStaticDefaults() {

--- a/NPCs/Riven/Spider_Amoeba.cs
+++ b/NPCs/Riven/Spider_Amoeba.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Xna.Framework;
+using Origins.Dev;
 using Origins.Items.Armor.Riven;
 using Origins.Items.Materials;
 using Origins.Items.Weapons.Demolitionist;
@@ -79,7 +80,8 @@ namespace Origins.NPCs.Riven {
             OriginPlayer.InflictTorn(target, 180, targetSeverity: 1f - 0.85f);
         }
     }
-	public class Spider_Amoeba_Wall : Spider_Amoeba {
+	public class Spider_Amoeba_Wall : Spider_Amoeba, ICustomWikiStat {
+		bool ICustomWikiStat.CanExportStats => false;
 		public override Color? GetGlowColor(Color drawColor) => Riven_Hive.GetGlowAlpha(drawColor);
 		public override void Load() { }
 		public override void SetStaticDefaults() {

--- a/NPCs/Riven/Spider_Amoeba.cs
+++ b/NPCs/Riven/Spider_Amoeba.cs
@@ -11,7 +11,11 @@ using Terraria.ID;
 using Terraria.ModLoader;
 
 namespace Origins.NPCs.Riven {
-    public class Spider_Amoeba : Glowing_Mod_NPC, IRivenEnemy {
+    public class Spider_Amoeba : Glowing_Mod_NPC, IRivenEnemy, IWikiNPC {
+		public Rectangle DrawRect => new(0, 4, 72, 34);
+		public int AnimationFrames => 32;
+		public int FrameDuration => 1;
+		public NPCExportType ImageExportType => NPCExportType.Bestiary;
 		public override Color? GetGlowColor(Color drawColor) => Riven_Hive.GetGlowAlpha(drawColor);
 		public AssimilationAmount? Assimilation => 0.04f;
 		public override void Load() => this.AddBanner();

--- a/NPCs/Riven/Torn_Ghoul.cs
+++ b/NPCs/Riven/Torn_Ghoul.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Xna.Framework;
+using Origins.Dev;
 using Origins.Items.Materials;
 using Origins.World.BiomeData;
 using Terraria;
@@ -8,7 +9,11 @@ using Terraria.ID;
 using Terraria.ModLoader;
 
 namespace Origins.NPCs.Riven {
-	public class Torn_Ghoul : Glowing_Mod_NPC, IRivenEnemy {
+	public class Torn_Ghoul : Glowing_Mod_NPC, IRivenEnemy, IWikiNPC {
+		public Rectangle DrawRect => new(0, 6, 36, 52);
+		public int AnimationFrames => 16;
+		public int FrameDuration => 1;
+		public NPCExportType ImageExportType => NPCExportType.Bestiary;
 		public override Color? GetGlowColor(Color drawColor) => Riven_Hive.GetGlowAlpha(drawColor);
 		public AssimilationAmount? Assimilation => 0.10f;
 		public override void SetStaticDefaults() {

--- a/NPCs/Riven/Trijaw_Shark.cs
+++ b/NPCs/Riven/Trijaw_Shark.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Xna.Framework;
+using Origins.Dev;
 using Origins.Items.Armor.Riven;
 using Origins.Items.Other.Consumables.Food;
 using Origins.World.BiomeData;
@@ -10,7 +11,11 @@ using Terraria.ID;
 using Terraria.ModLoader;
 
 namespace Origins.NPCs.Riven {
-	public class Trijaw_Shark : Glowing_Mod_NPC, ICustomCollisionNPC {
+	public class Trijaw_Shark : Glowing_Mod_NPC, ICustomCollisionNPC, IWikiNPC {
+		public Rectangle DrawRect => new(0, -6, 96, 40);
+		public int AnimationFrames => 16;
+		public int FrameDuration => 1;
+		public NPCExportType ImageExportType => NPCExportType.Bestiary;
 		public override Color? GetGlowColor(Color drawColor) => Riven_Hive.GetGlowAlpha(drawColor);
 		public bool IsSandshark => true;
 		public override void Load() => this.AddBanner();

--- a/NPCs/Riven/World_Cracker/World_Cracker_Exoskeleton.cs
+++ b/NPCs/Riven/World_Cracker/World_Cracker_Exoskeleton.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Xna.Framework.Graphics;
+using Origins.Dev;
 using PegasusLib;
 using System;
 using System.Collections.Generic;
@@ -9,7 +10,11 @@ using Terraria.ID;
 using Terraria.ModLoader;
 
 namespace Origins.NPCs.Riven.World_Cracker {
-	public class World_Cracker_Exoskeleton : Glowing_Mod_NPC, IRivenEnemy {
+	public class World_Cracker_Exoskeleton : Glowing_Mod_NPC, IRivenEnemy, IWikiNPC {
+		public Rectangle DrawRect => new(0, 0, 50, 26);
+		public int AnimationFrames => 3;
+		public int FrameDuration => 6;
+		public NPCExportType ImageExportType => NPCExportType.SpriteSheet;
 		public AssimilationAmount? Assimilation => 0.03f;
 		public override string Texture => "Origins/Items/Weapons/Summoner/Minions/Flying_Exoskeleton";
 		public override void SetStaticDefaults() {

--- a/NPCs/Riven/World_Cracker/World_Cracker_Summon_Bubble.cs
+++ b/NPCs/Riven/World_Cracker/World_Cracker_Summon_Bubble.cs
@@ -14,7 +14,11 @@ using Terraria.Localization;
 using Origins.Dev;
 
 namespace Origins.NPCs.Riven.World_Cracker {
-	public class World_Cracker_Summon_Bubble : Glowing_Mod_NPC, IRivenEnemy {
+	public class World_Cracker_Summon_Bubble : Glowing_Mod_NPC, IRivenEnemy, IWikiNPC {
+		public Rectangle DrawRect => new(0, 0, 50, 52);
+		public int AnimationFrames => 4;
+		public int FrameDuration => 8;
+		public NPCExportType ImageExportType => NPCExportType.SpriteSheet;
 		public static int ID { get; private set; }
 		public static List<int> ValidSpawns { get; private set; } = [];
 		public override void SetStaticDefaults() {

--- a/NPCs/Riven/World_Cracker/World_Cracker_Summon_Bubble.cs
+++ b/NPCs/Riven/World_Cracker/World_Cracker_Summon_Bubble.cs
@@ -11,6 +11,7 @@ using Terraria.ModLoader;
 using Terraria;
 using PegasusLib;
 using Terraria.Localization;
+using Origins.Dev;
 
 namespace Origins.NPCs.Riven.World_Cracker {
 	public class World_Cracker_Summon_Bubble : Glowing_Mod_NPC, IRivenEnemy {
@@ -114,7 +115,8 @@ namespace Origins.NPCs.Riven.World_Cracker {
 		}
 		public override Color? GetGlowColor(Color drawColor) => Riven_Hive.GetGlowAlpha(drawColor);
 	}
-	public class Riven_Fighter_WC : Riven_Fighter {
+	public class Riven_Fighter_WC : Riven_Fighter, ICustomWikiStat {
+		string ICustomWikiStat.CustomStatPath => nameof(Riven_Fighter_WC);
 		public override string Texture => typeof(Riven_Fighter).GetDefaultTMLName();
 		public override LocalizedText DisplayName => Language.GetOrRegister(Mod.GetLocalizationKey($"{LocalizationCategory}.Riven_Fighter.DisplayName"));
 		public override void Load() { }
@@ -128,7 +130,8 @@ namespace Origins.NPCs.Riven.World_Cracker {
 			this.CopyBanner<Riven_Fighter>();
 		}
 	}
-	public class Amebic_Slime_WC : Amebic_Slime {
+	public class Amebic_Slime_WC : Amebic_Slime, ICustomWikiStat {
+		string ICustomWikiStat.CustomStatPath => nameof(Amebic_Slime_WC);
 		public override string Texture => typeof(Amebic_Slime).GetDefaultTMLName();
 		public override LocalizedText DisplayName => Language.GetOrRegister(Mod.GetLocalizationKey($"{LocalizationCategory}.Amebic_Slime.DisplayName"));
 		public override void Load() { }
@@ -142,7 +145,8 @@ namespace Origins.NPCs.Riven.World_Cracker {
 			this.CopyBanner<Amebic_Slime>();
 		}
 	}
-	public class Amoeba_Bugger_WC : Amoeba_Bugger {
+	public class Amoeba_Bugger_WC : Amoeba_Bugger, ICustomWikiStat {
+		string ICustomWikiStat.CustomStatPath => nameof(Amoeba_Bugger_WC);
 		public override string Texture => typeof(Amoeba_Bugger).GetDefaultTMLName();
 		public override LocalizedText DisplayName => Language.GetOrRegister(Mod.GetLocalizationKey($"{LocalizationCategory}.Amoeba_Bugger.DisplayName"));
 		public override void Load() { }
@@ -155,7 +159,8 @@ namespace Origins.NPCs.Riven.World_Cracker {
 			NPC.lifeMax /= 2;
 		}
 	}
-	public class World_Cracker_Exoskeleton_WC : World_Cracker_Exoskeleton {
+	public class World_Cracker_Exoskeleton_WC : World_Cracker_Exoskeleton, ICustomWikiStat {
+		string ICustomWikiStat.CustomStatPath => nameof(World_Cracker_Exoskeleton_WC);
 		public override LocalizedText DisplayName => Language.GetOrRegister(Mod.GetLocalizationKey($"{LocalizationCategory}.World_Cracker_Exoskeleton.DisplayName"));
 		public override void Load() { }
 		public override void SetStaticDefaults() {

--- a/NPCs/TownNPCs/Brine_Fiend.cs
+++ b/NPCs/TownNPCs/Brine_Fiend.cs
@@ -1,5 +1,6 @@
 ﻿using AltLibrary.Core;
 using Microsoft.Xna.Framework.Graphics;
+using Origins.Dev;
 using Origins.Items.Other.Consumables.Broths;
 using Origins.Projectiles.Weapons;
 using Origins.Tiles.Brine;
@@ -19,7 +20,11 @@ using Terraria.Utilities;
 
 namespace Origins.NPCs.TownNPCs {
 	[AutoloadHead]
-	public class Brine_Fiend : ModNPC {
+	public class Brine_Fiend : ModNPC, IWikiNPC {
+		public Rectangle DrawRect => new(0, 6, 36, 48);
+		public int AnimationFrames => 16;
+		public int FrameDuration => 2;
+		public NPCExportType ImageExportType => NPCExportType.Bestiary;
 		public override void SetStaticDefaults() {
 			Main.npcFrameCount[Type] = 23; // The amount of frames the NPC has, walk frame count (15) + ExtraFramesCount
 

--- a/NPCs/TownNPCs/Defiled_Effigy.cs
+++ b/NPCs/TownNPCs/Defiled_Effigy.cs
@@ -1,6 +1,7 @@
 ﻿using AltLibrary.Core;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
+using Origins.Dev;
 using Origins.Items.Weapons.Magic;
 using Origins.World.BiomeData;
 using ReLogic.Content;
@@ -17,7 +18,11 @@ using Terraria.Utilities;
 
 namespace Origins.NPCs.TownNPCs {
 	[AutoloadHead]
-	public class Defiled_Effigy : ModNPC {
+	public class Defiled_Effigy : ModNPC, IWikiNPC {
+		public Rectangle DrawRect => new(0, 0, 40, 54);
+		public int AnimationFrames => 1;
+		public int FrameDuration => 1;
+		public NPCExportType ImageExportType => NPCExportType.SpriteSheet;
 		public override void SetStaticDefaults() {
 			Main.npcFrameCount[Type] = 1; // The amount of frames the NPC has, walk frame count (15) + ExtraFramesCount
 

--- a/Reflection/ModBestiaryInfoElementMethods.cs
+++ b/Reflection/ModBestiaryInfoElementMethods.cs
@@ -1,0 +1,16 @@
+﻿using PegasusLib;
+using System.Reflection;
+using Terraria.GameContent.Bestiary;
+using Terraria.ModLoader;
+
+namespace Origins.Reflection;
+public class ModBestiaryInfoElementMethods : ILoadable {
+	public static FastFieldInfo<ModBestiaryInfoElement, Mod> _mod;
+	public void Load(Mod mod) {
+		_mod = new(nameof(_mod), BindingFlags.NonPublic | BindingFlags.Instance);
+	}
+
+	public void Unload() {
+		_mod = null;
+	}
+}


### PR DESCRIPTION
### Changes
Adds `IWikiNPC` implementations to all NPCs for generating their wiki images.
Fixed animations not looping forever
Added `Environments` to NPC stats which are taken from the bestiary tags
Added the following to the IWikiNPC interface:
- `FrameDuration` - How many times each frame gets repeated. Useful for manipulating frame rates on some NPCs
- `ImageExportType` - Can either be `Bestiary` or `SpriteSheet`. Bestiary is the default and original behavior. SpriteSheet takes directly from the sprite sheet to create the animation. It is particularly useful for slimes due to their opacity.
- `FrameRange` - Configures which frames to use in the animation. This is useful for animations that do not inherently loop well, so you can just use a range of frames that loop well as opposed to the whole animation. See `SeaDragon` for a good example.

### Notes
Some of the framerates may be a little off. I tried to match the bestiary profile as much as possible. But now it should be easily configurable if changes need to be made.
I mostly ignored worms opting to just use their custom bestiary image.
